### PR TITLE
Update GS query

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/migration/query/WaElasticSearchQuery.java
+++ b/src/main/java/uk/gov/hmcts/reform/migration/query/WaElasticSearchQuery.java
@@ -11,30 +11,30 @@ public class WaElasticSearchQuery extends AbstractElasticQuery implements Elasti
         {
           "query": {
             "bool": {
-                "must_not": [
+                "should": [
                     {
-                        "exists": {
-                            "field": "data.preWorkAllocation"
-                         }
-                        },
-                        {
-                            "match": {
-                                "state": "draft"
+                        "bool": {
+                            "must_not": [
+                                { "exists": { "field": "data.preWorkAllocation" }},
+                                { "match": { "state": "draft" }}
+                            ]
+                        }
+                    },
+                    {
+                        "bool": {
+                            "must_not": [
+                                { "exists": { "field": "data.SearchCriteria.OtherCaseReferences" }},
+                                { "match": { "state": "draft" }}
+                            ]
                         }
                     }
-                ]
+                 ]
             }
           },
-          "_source": [
-            "reference"
-          ],
+          "_source": [ "reference" ],
           "size": %s,
-          "sort": [
-            {
-              "reference.keyword": "asc"
-            }
-          ]
-          """;
+          "sort": [ { "reference.keyword": "asc" } ]
+        """;
 
     @Override
     protected String getStartQuery() {

--- a/src/test/java/uk/gov/hmcts/reform/migration/query/WaElasticSearchQueryTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/migration/query/WaElasticSearchQueryTest.java
@@ -15,30 +15,30 @@ class WaElasticSearchQueryTest {
         {
           "query": {
             "bool": {
-                "must_not": [
+                "should": [
                     {
-                        "exists": {
-                            "field": "data.preWorkAllocation"
-                         }
-                        },
-                        {
-                            "match": {
-                                "state": "draft"
+                        "bool": {
+                            "must_not": [
+                                { "exists": { "field": "data.preWorkAllocation" }},
+                                { "match": { "state": "draft" }}
+                            ]
+                        }
+                    },
+                    {
+                        "bool": {
+                            "must_not": [
+                                { "exists": { "field": "data.SearchCriteria.OtherCaseReferences" }},
+                                { "match": { "state": "draft" }}
+                            ]
                         }
                     }
-                ]
+                 ]
             }
           },
-          "_source": [
-            "reference"
-          ],
+          "_source": [ "reference" ],
           "size": 100,
-          "sort": [
-            {
-              "reference.keyword": "asc"
-            }
-          ]
-           }""".replaceAll("\\s", ""), query.replaceAll("\\s", ""));
+          "sort": [ { "reference.keyword": "asc" } ]
+        }""".replaceAll("\\s", ""), query.replaceAll("\\s", ""));
     }
 
     @Test
@@ -49,30 +49,30 @@ class WaElasticSearchQueryTest {
         {
           "query": {
             "bool": {
-                "must_not": [
+                "should": [
                     {
-                        "exists": {
-                            "field": "data.preWorkAllocation"
-                         }
-                        },
-                        {
-                            "match": {
-                                "state": "draft"
+                        "bool": {
+                            "must_not": [
+                                { "exists": { "field": "data.preWorkAllocation" }},
+                                { "match": { "state": "draft" }}
+                            ]
+                        }
+                    },
+                    {
+                        "bool": {
+                            "must_not": [
+                                { "exists": { "field": "data.SearchCriteria.OtherCaseReferences" }},
+                                { "match": { "state": "draft" }}
+                            ]
                         }
                     }
-                ]
+                 ]
             }
           },
-          "_source": [
-            "reference"
-          ],
+          "_source": [ "reference" ],
           "size": 100,
-          "sort": [
-            {
-              "reference.keyword": "asc"
-            }
-          ],
+          "sort": [ { "reference.keyword": "asc" } ],
           "search_after": [1677777777]
-           }""".replaceAll("\\s", ""), query.replaceAll("\\s", ""));
+        }""".replaceAll("\\s", ""), query.replaceAll("\\s", ""));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/migration/query/WaElasticSearchQueryTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/migration/query/WaElasticSearchQueryTest.java
@@ -38,7 +38,8 @@ class WaElasticSearchQueryTest {
           "_source": [ "reference" ],
           "size": 100,
           "sort": [ { "reference.keyword": "asc" } ]
-        }""".replaceAll("\\s", ""), query.replaceAll("\\s", ""));
+        }
+            """.replaceAll("\\s", ""), query.replaceAll("\\s", ""));
     }
 
     @Test
@@ -73,6 +74,7 @@ class WaElasticSearchQueryTest {
           "size": 100,
           "sort": [ { "reference.keyword": "asc" } ],
           "search_after": [1677777777]
-        }""".replaceAll("\\s", ""), query.replaceAll("\\s", ""));
+        }
+            """.replaceAll("\\s", ""), query.replaceAll("\\s", ""));
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SSCS-12419


### Change description ###
Global search migration needs to be update to pick cases that have the preWorkAllocation field populated but are missing the SearchCriteria.OtherReferences fields.
