### PR TITLE
Update spring security to fix CVE-2023-34034

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -170,13 +170,13 @@ ext {
   junitJupiterVersion = '5.9.3'
   junitVintageVersion = '5.9.3'
   powermockVersion = '2.0.9'
-  springSecurity   =  '5.8.9'
+  springSecurity   =  '5.8.12'
   springCloudVersion = '2021.0.9'
 }
 
 ext['jackson.version'] = '2.15.3'
 ext['snakeyaml.version'] = '2.0'
-ext['spring-security.version'] = '5.7.8'
+ext['spring-security.version'] = '5.7.12'
 
 dependencies {
   implementation("org.springframework.cloud:spring-cloud-starter-bootstrap")

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,17 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?><suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
   <suppress>
-    <notes>Temporary Suppression
-        CVE-2022-1471 refer https://tools.hmcts.net/jira/browse/CCD-4454
-        CVE-2023-34035 refer [Ticket]
-        CVE-2023-34034 refer [Ticket]
-    
-        CVE-2023-34055 refer [Ticket]
-        CVE-2023-6378 refer [Ticket]
-        CVE-2023-35116 refer [Ticket]
-        CVE-2023-6481 refer [Ticket]</notes>
-    <cve>CVE-2023-34035</cve>
-    <cve>CVE-2023-34034</cve>
-    <cve>CVE-2023-34055</cve>
     <cve>CVE-2023-6378</cve>
     <cve>CVE-2023-35116</cve>
     <cve>CVE-2023-6481</cve>


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SSCSCI-848

### Change description ###

Updated spring-security to 5.8.12 (latest minor version)
Also removed CVE-2023-34035 and CVE-2023-34055 from suppressions as these were fixed

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
