### PR TITLE
SSCSCI XML parser fix

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+systemProp.javax.xml.parsers.SAXParserFactory=com.sun.org.apache.xerces.internal.jaxp.SAXParserFactoryImpl


### PR DESCRIPTION
### Change description ###

The two plugins `[com.github.kt3k.coveralls](https://github.com/kt3k/coveralls-gradle-plugin/)` `2.12.2` and `com.github.ben-manes.versions` `0.52.0` use a different XML parser. `com.github.kt3k.coveralls` (last updated in 2023) is using the outdated `` while `com.github.ben-manes.versions` uses ``. But [Gradle requires XML parsers to be recent](https://docs.gradle.org/current/userguide/upgrading_version_8.html#xml_parsing_now_requires_recent_parsers):

> Gradle 8.4 now configures XML parsers with security features enabled. If your build logic depends on old XML parsers that don’t support secure parsing, your build may fail. If you encounter a failure, check and update or remove any dependency on legacy XML parsers.

We can force the use of the XML parsers built into the JVM until `com.github.kt3k.coveralls` updates it's parser.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
