### PR TITLE
SSCSCI-1729: only migrate cases without panelComp

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/migration/query/DefaultPanelCompositionQuery.java
+++ b/src/main/java/uk/gov/hmcts/reform/migration/query/DefaultPanelCompositionQuery.java
@@ -11,7 +11,25 @@ public class DefaultPanelCompositionQuery extends ElasticSearchQuery {
             "bool": {
               "must": [
                 { "match": { "state": "readyToList" }},
-                { "match": { "data.hearingRoute": "listAssist" }}
+                { "match": { "data.hearingRoute": "listAssist" }},
+                {
+                  "bool": {
+                    "must": [
+                      { "bool": { "must_not": { "exists": { "field": "data.panelMemberComposition.districtTribunalJudge" } } } },
+                      { "bool": { "must_not": { "exists": { "field": "data.panelMemberComposition.panelCompositionJudge" } } } },
+                      { "bool": { "must_not": { "exists": { "field": "data.panelMemberComposition.panelCompositionMemberMedical1" } } } },
+                      { "bool": { "must_not": { "exists": { "field": "data.panelMemberComposition.panelCompositionMemberMedical2" } } } },
+                      {
+                        "bool": {
+                          "should": [
+                            { "bool": { "must_not": { "exists": { "field": "data.panelMemberComposition.panelCompositionDisabilityAndFqMember" } } } },
+                            { "script": { "script": "doc['data.panelMemberComposition.panelCompositionDisabilityAndFqMember'].size() == 0" } }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
               ]
             }
           },

--- a/src/main/java/uk/gov/hmcts/reform/migration/service/migrate/DefaultPanelCompositionMigration.java
+++ b/src/main/java/uk/gov/hmcts/reform/migration/service/migrate/DefaultPanelCompositionMigration.java
@@ -19,6 +19,7 @@ import uk.gov.hmcts.reform.sscs.ccd.service.UpdateCcdCaseService.UpdateResult;
 import java.util.List;
 import java.util.Optional;
 
+import static java.util.Objects.isNull;
 import static uk.gov.hmcts.reform.migration.repository.EncodedStringCaseList.findCases;
 import static uk.gov.hmcts.reform.sscs.ccd.domain.State.READY_TO_LIST;
 
@@ -58,10 +59,13 @@ public class DefaultPanelCompositionMigration extends CaseMigrationProcessor {
         } else {
             return repository.findCases(searchQuery, true)
                 .stream()
-                .filter(caseDetails -> READY_TO_LIST.toString().equals(caseDetails.getState())
-                    && caseDetails.getData().getSchedulingAndListingFields().getHearingRoute()
-                    .equals(HearingRoute.LIST_ASSIST))
-                .toList();
+                .filter(caseDetails -> {
+                    var hearingRoute = caseDetails.getData().getSchedulingAndListingFields().getHearingRoute();
+                    var panelComposition = caseDetails.getData().getPanelMemberComposition();
+                    return READY_TO_LIST.toString().equals(caseDetails.getState())
+                        && HearingRoute.LIST_ASSIST.equals(hearingRoute)
+                        && (isNull(panelComposition) || panelComposition.isEmpty());
+                }).toList();
         }
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/migration/service/migrate/DefaultPanelCompositionMigrationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/migration/service/migrate/DefaultPanelCompositionMigrationTest.java
@@ -16,6 +16,7 @@ import uk.gov.hmcts.reform.migration.query.DefaultPanelCompositionQuery;
 import uk.gov.hmcts.reform.migration.repository.ElasticSearchRepository;
 import uk.gov.hmcts.reform.sscs.ccd.domain.AmendReason;
 import uk.gov.hmcts.reform.sscs.ccd.domain.HearingRoute;
+import uk.gov.hmcts.reform.sscs.ccd.domain.PanelMemberComposition;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SchedulingAndListingFields;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseDetails;
@@ -68,13 +69,18 @@ class DefaultPanelCompositionMigrationTest {
         var caseB = buildCaseWith("readyToList", HearingRoute.GAPS);
         var caseC = buildCaseWith("draft", HearingRoute.LIST_ASSIST);
         var caseD = buildCaseWith("validAppeal", HearingRoute.LIST_ASSIST);
-        List<SscsCaseDetails> caseList = List.of(caseA, caseB, caseC, caseD);
+        var caseE = buildCaseWith("readyToList", HearingRoute.LIST_ASSIST);
+        caseE.getData().setPanelMemberComposition(new PanelMemberComposition());
+        var caseF = buildCaseWith("readyToList", HearingRoute.LIST_ASSIST);
+        caseF.getData().setPanelMemberComposition(new PanelMemberComposition(List.of("84")));
+
+        List<SscsCaseDetails> caseList = List.of(caseA, caseB, caseC, caseD, caseE, caseF);
         when(repository.findCases(searchQuery, true)).thenReturn(caseList);
 
         List<SscsCaseDetails> migrationCases = underTest.fetchCasesToMigrate();
 
-        assertThat(migrationCases).hasSize(1);
-        assertThat(migrationCases).contains(caseA);
+        assertThat(migrationCases).hasSize(2);
+        assertThat(migrationCases).containsOnly(caseA, caseE);
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###
- https://tools.hmcts.net/jira/browse/SSCSCI-1729

### Change description ###
- restrict ILA migration to cases where panelMemberComposition is null or empty


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
