### PR TITLE
SSCSCI-1982: final decision outcome with non completed hearings

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/migration/service/migrate/MultipleHearingsOutcomeMigration.java
+++ b/src/main/java/uk/gov/hmcts/reform/migration/service/migrate/MultipleHearingsOutcomeMigration.java
@@ -28,6 +28,8 @@ import static uk.gov.hmcts.reform.migration.repository.EncodedStringCaseList.map
 @ConditionalOnProperty(value = "migration.multipleHearingsOutcomes.enabled", havingValue = "true")
 public class MultipleHearingsOutcomeMigration extends CaseOutcomeMigration {
 
+    static final String OUTCOME_MIGRATION_MULTIPLE_HEARINGS_SUMMARY = "Migrate Outcome to Hearing Outcome";
+    static final String OUTCOME_MIGRATION_MULTIPLE_HEARINGS_DESCRIPTION = "Link Outcome to completed Hearing";
     private final HmcHearingsApiService hmcHearingsApiService;
     private final HearingOutcomeService hearingOutcomeService;
     private final ObjectMapper objectMapper;
@@ -79,5 +81,15 @@ public class MultipleHearingsOutcomeMigration extends CaseOutcomeMigration {
             hearingOutcomeService.mapHmcHearingToHearingOutcome(getHmcHearing(caseId), data, getOutcomeFieldName());
         existingHearingOutcomes.addAll(mappedHearingOutcomes);
         data.put("hearingOutcomes", existingHearingOutcomes);
+    }
+
+    @Override
+    public String getEventDescription() {
+        return OUTCOME_MIGRATION_MULTIPLE_HEARINGS_DESCRIPTION;
+    }
+
+    @Override
+    public String getEventSummary() {
+        return OUTCOME_MIGRATION_MULTIPLE_HEARINGS_SUMMARY;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/migration/service/migrate/MultipleHearingsOutcomeMigration.java
+++ b/src/main/java/uk/gov/hmcts/reform/migration/service/migrate/MultipleHearingsOutcomeMigration.java
@@ -30,6 +30,8 @@ public class MultipleHearingsOutcomeMigration extends CaseOutcomeMigration {
 
     static final String OUTCOME_MIGRATION_MULTIPLE_HEARINGS_SUMMARY = "Migrate Outcome to Hearing Outcome";
     static final String OUTCOME_MIGRATION_MULTIPLE_HEARINGS_DESCRIPTION = "Link Outcome to completed Hearing";
+    public static final String OUTCOME = "outcome";
+
     private final HmcHearingsApiService hmcHearingsApiService;
     private final HearingOutcomeService hearingOutcomeService;
     private final ObjectMapper objectMapper;
@@ -68,7 +70,7 @@ public class MultipleHearingsOutcomeMigration extends CaseOutcomeMigration {
             .map(HearingOutcomeDetails::getCompletedHearingId)
             .anyMatch(caseRefToHearingIdMap::containsValue);
 
-        return isNull(sscsCaseData.getCaseOutcome().getCaseOutcome()) || isSelectedHearingUsed;
+        return isNull(data.get(getOutcomeFieldName())) || isSelectedHearingUsed;
     }
 
     @Override
@@ -81,6 +83,11 @@ public class MultipleHearingsOutcomeMigration extends CaseOutcomeMigration {
             hearingOutcomeService.mapHmcHearingToHearingOutcome(getHmcHearing(caseId), data, getOutcomeFieldName());
         existingHearingOutcomes.addAll(mappedHearingOutcomes);
         data.put("hearingOutcomes", existingHearingOutcomes);
+    }
+
+    @Override
+    public String getOutcomeFieldName() {
+        return OUTCOME;
     }
 
     @Override


### PR DESCRIPTION
### JIRA link (if applicable) ###

[SSCSCI-1982](https://tools.hmcts.net/jira/browse/SSCSCI-1982)

### Change description ###

Amended existing multipleHearingsOutcomes to use the outcome field.
Tested in AAT with cases: 

- 1739348317769197 with hearings 2030052480 (expected to fail) then 2030052487 (expected to pass)
- 1739348731868237 with hearing 2030033116 (expected to pass)
- 1739433795794238 with hearing 2030033174 (expected to fail)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
