### PR TITLE
SSCSCI: Bump java plugin and fix CVEs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,11 +5,11 @@ plugins {
   id 'java'
   id 'io.freefair.lombok' version '8.14.2'
   id 'io.spring.dependency-management' version '1.1.7'
-  id 'org.springframework.boot' version '3.5.13'
+  id 'org.springframework.boot' version '3.5.14'
   id 'com.github.kt3k.coveralls' version '2.12.2'
   id 'com.github.ben-manes.versions' version '0.52.0'
   id 'org.sonarqube' version '4.4.1.3373'
-  id 'uk.gov.hmcts.java' version '0.12.67'
+  id 'uk.gov.hmcts.java' version '0.12.70'
   id 'org.owasp.dependencycheck' version '12.1.3'
 }
 
@@ -196,6 +196,8 @@ ext {
   powermockVersion = '2.0.9'
   springCloudVersion = '2025.0.0'
   jacksonVersion = '2.20.0'
+  set('log4j2.version', '2.26.0')
+  set('commons-lang3.version', '3.20.0')
 }
 
 dependencyManagement {

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,2 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd"/>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+  <suppress until="2026-06-07">
+    <cve>CVE-2025-15104</cve>
+  </suppress>
+</suppressions>


### PR DESCRIPTION
### Change description

#### Updates

| Name | Change | Relates to |
| --- | --- | --- |
| [org.springframework.boot](https://spring.io/projects/spring-boot) | `3.5.13` -> `3.5.14` |  |
| uk.gov.hmcts.java | `0.12.67` -> `0.12.70` |  |
| log4j2 | `2.24.3` -> `2.26.0` | CVE-2026-34478, CVE-2026-34479, CVE-2026-34480, CVE-2025-68161, CVE-2026-34477 |
| commons-lang3 | `3.17.0` -> `3.20.0` | CVE-2025-48924 |

#### Suppressed CVEs

| CVE | Why |
| --- | --- |
| CVE-2025-15104 | CPE False Positive, flagged for [json-schema-validator](https://github.com/networknt/json-schema-validator) but vulnerability affects [The Nu Html Checker](https://github.com/validator/validator) |

### Testing done

Pipeline passes and run against AAT from local

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [x] Yes
  * [ ] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
