### PR TITLE
SSCSCI-2665: Interpreter language migration to MRD code

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
   id 'org.springframework.boot' version '3.5.16'
   id 'com.github.kt3k.coveralls' version '2.12.2'
   id 'com.github.ben-manes.versions' version '0.54.0'
-  id 'org.sonarqube' version '7.3.1.8318'
+  id 'org.sonarqube' version '6.2.0.5505'
   id 'uk.gov.hmcts.java' version '0.12.70'
   id 'org.owasp.dependencycheck' version '12.1.3'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -3,12 +3,13 @@ plugins {
   id 'checkstyle'
   id 'jacoco'
   id 'java'
-  id 'io.freefair.lombok' version '8.14.2'
+  id 'io.freefair.lombok' version '8.14.4'
   id 'io.spring.dependency-management' version '1.1.7'
-  id 'org.springframework.boot' version '3.5.14'
+  id 'org.springframework.boot' version '3.5.16'
   id 'com.github.kt3k.coveralls' version '2.12.2'
   id 'com.github.ben-manes.versions' version '0.52.0'
   id 'org.sonarqube' version '4.4.1.3373'
+  id 'com.github.ben-manes.versions' version '0.54.0'
   id 'uk.gov.hmcts.java' version '0.12.70'
   id 'org.owasp.dependencycheck' version '12.1.3'
 }
@@ -109,7 +110,7 @@ tasks.register('smoke', Test) {
 
 checkstyle {
   maxWarnings = 0
-  toolVersion = '11.0.1'
+  toolVersion = '13.7.0'
   getConfigDirectory().set(new File(rootDir, 'config/checkstyle'))
 }
 
@@ -190,13 +191,13 @@ repositories {
 }
 
 ext {
-  lombokVersion = "1.18.40"
-  junitVersion = '5.13.4'
-  junitPlatform = '1.13.4'
+  lombokVersion = '1.18.46'
+  junitVersion = '5.14.4'
+  junitPlatform = '1.14.4'
   powermockVersion = '2.0.9'
-  springCloudVersion = '2025.0.0'
+  springCloudVersion = '2025.0.3'
   jacksonVersion = '2.22.0'
-  set('log4j2.version', '2.26.0')
+  set('log4j2.version', '2.26.1')
   set('commons-lang3.version', '3.20.0')
   set('spring-framework.version', '6.2.19')
   set('spring-security.version', '6.5.11')
@@ -236,8 +237,8 @@ dependencies {
   implementation group: 'org.springframework.security', name: 'spring-security-config'
 
   implementation group: 'com.github.hmcts', name: 'idam-java-client', version: '3.0.5'
-  implementation group: 'com.github.hmcts', name: 'service-auth-provider-java-client', version: '5.3.3'
-  implementation group: 'com.github.hmcts', name: 'core-case-data-store-client', version: '5.2.0'
+  implementation group: 'com.github.hmcts', name: 'service-auth-provider-java-client', version: '5.3.4'
+  implementation group: 'com.github.hmcts', name: 'core-case-data-store-client', version: '5.3.0'
   implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: '8.0.0'
   implementation group: 'com.github.hmcts', name: 'sscs-common', version: '6.3.55'
 
@@ -250,10 +251,10 @@ dependencies {
   implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: jacksonVersion
   implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jdk8', version: jacksonVersion
 
-  implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.8.13'
+  implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.8.17'
   implementation group: 'net.logstash.logback', name: 'logstash-logback-encoder', version: '8.1'
   implementation group: 'commons-fileupload', name: 'commons-fileupload', version: '1.6.0'
-  implementation group: 'commons-io', name: 'commons-io', version: '2.20.0'
+  implementation group: 'commons-io', name: 'commons-io', version: '2.22.0'
 
   implementation group: 'org.projectlombok', name: 'lombok', version: lombokVersion
   annotationProcessor group: 'org.projectlombok', name: 'lombok', version: lombokVersion
@@ -261,14 +262,14 @@ dependencies {
 
   testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test'
   testImplementation group: 'org.wiremock.integrations', name: 'wiremock-spring-boot', version: '3.10.6'
-  testImplementation group: 'io.rest-assured', name: 'rest-assured', version: '5.5.6'
-  testImplementation group: 'io.rest-assured', name: 'xml-path', version: '5.5.6'
-  testImplementation group: 'io.rest-assured', name: 'json-path', version: '5.5.6'
+  testImplementation group: 'io.rest-assured', name: 'rest-assured', version: '5.5.7'
+  testImplementation group: 'io.rest-assured', name: 'xml-path', version: '5.5.7'
+  testImplementation group: 'io.rest-assured', name: 'json-path', version: '5.5.7'
 
   testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: junitVersion
   testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: junitVersion
   testRuntimeOnly group: 'org.junit.vintage', name: 'junit-vintage-engine', version: junitVersion
-  testImplementation group:'org.mockito', name: 'mockito-junit-jupiter', version: '5.19.0'
+  testImplementation group:'org.mockito', name: 'mockito-junit-jupiter', version: '5.23.0'
   testImplementation group: 'org.powermock', name: 'powermock-api-mockito2', version: powermockVersion
   testImplementation group: 'org.powermock', name: 'powermock-module-junit4', version: powermockVersion
 

--- a/build.gradle
+++ b/build.gradle
@@ -211,6 +211,12 @@ dependencyManagement {
   dependencies {
     // CVE-2026-56148, CVE-2026-56149
     dependency group: 'org.elasticsearch', name: 'elasticsearch', version: '8.19.18'
+
+    // CVE-2026-54399, CVE-2026-54428
+    dependencySet(group: 'org.apache.httpcomponents.core5', version: '5.4.3') {
+      entry 'httpcore5'
+      entry 'httpcore5-h2'
+    }
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
   id 'org.springframework.boot' version '3.5.16'
   id 'com.github.kt3k.coveralls' version '2.12.2'
   id 'com.github.ben-manes.versions' version '0.54.0'
-  id 'org.sonarqube' version '6.2.0.5505'
+  id 'org.sonarqube' version '5.1.0.4882'
   id 'uk.gov.hmcts.java' version '0.12.70'
   id 'org.owasp.dependencycheck' version '12.1.3'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -195,7 +195,7 @@ ext {
   junitPlatform = '1.13.4'
   powermockVersion = '2.0.9'
   springCloudVersion = '2025.0.0'
-  jacksonVersion = '2.20.0'
+  jacksonVersion = '2.22.0'
   set('log4j2.version', '2.26.0')
   set('commons-lang3.version', '3.20.0')
   set('spring-framework.version', '6.2.19')

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
   id 'org.springframework.boot' version '3.5.16'
   id 'com.github.kt3k.coveralls' version '2.12.2'
   id 'com.github.ben-manes.versions' version '0.54.0'
-  id 'org.sonarqube' version '6.2.0.5505'
+  id 'org.sonarqube' version '7.3.1.8318'
   id 'uk.gov.hmcts.java' version '0.12.70'
   id 'org.owasp.dependencycheck' version '12.1.3'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -191,7 +191,7 @@ dependencies {
 
   implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.17'
   implementation 'net.logstash.logback:logstash-logback-encoder:8.1'
-  implementation 'org.apache.commons:commons-fileupload2-jakarta-servlet6:2.0.0-M5'
+  implementation 'org.apache.commons:commons-fileupload:1.6.0'
   implementation 'commons-io:commons-io:2.22.0'
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -22,89 +22,48 @@ java {
   }
 }
 
-sourceSets {
-  functionalTest {
-    java {
-      compileClasspath += main.output
-      runtimeClasspath += main.output
-      srcDir file('src/functionalTest/java')
+testing {
+  suites {
+    test {
+      useJUnitJupiter()
     }
-    resources.srcDir file('src/functionalTest/resources')
-  }
-
-  integrationTest {
-    java {
-      compileClasspath += main.output
-      runtimeClasspath += main.output
-      srcDir file('src/integrationTest/java')
+    functionalTest(JvmTestSuite) {
+      dependencies { implementation project() }
     }
-    resources.srcDir file('src/integrationTest/resources')
-  }
-
-  smokeTest {
-    java {
-      compileClasspath += main.output
-      runtimeClasspath += main.output
-      srcDir file('src/smokeTest/java')
+    integrationTest(JvmTestSuite) {
+      dependencies { implementation project() }
+      targets { all { testTask.configure { failFast = true } } }
     }
-    resources.srcDir file('src/smokeTest/resources')
+    smokeTest(JvmTestSuite) {
+      dependencies { implementation project() }
+    }
   }
-}
-
-configurations {
-  functionalTestImplementation.extendsFrom testImplementation
-  functionalTestRuntimeOnly.extendsFrom runtimeOnly
-
-  integrationTestImplementation.extendsFrom testImplementation
-  integrationTestRuntimeOnly.extendsFrom runtimeOnly
-
-  smokeTestImplementation.extendsFrom testImplementation
-  smokeTestRuntimeOnly.extendsFrom runtimeOnly
 }
 
 tasks.withType(JavaCompile).configureEach {
   options.compilerArgs << "-Xlint:unchecked"
 }
 
-// https://github.com/gradle/gradle/issues/16791
 tasks.withType(JavaExec).configureEach {
   javaLauncher.set(javaToolchains.launcherFor(java.toolchain))
 }
 
 tasks.withType(Test).configureEach {
   useJUnitPlatform()
-
   testLogging {
     exceptionFormat = 'full'
   }
 }
 
-tasks.register('functional', Test) {
-  description = "Runs functional tests"
-  group = "Verification"
-  testClassesDirs = sourceSets.functionalTest.output.classesDirs
-  classpath = sourceSets.functionalTest.runtimeClasspath
-}
-
-tasks.register('integration', Test) {
-  description = "Runs integration tests"
-  group = "Verification"
-  testClassesDirs = sourceSets.integrationTest.output.classesDirs
-  classpath = sourceSets.integrationTest.runtimeClasspath
-  failFast = true
-}
+tasks.register('functional') { dependsOn functionalTest }
+tasks.register('integration') { dependsOn integrationTest }
+tasks.register('smoke') { dependsOn smokeTest }
 
 tasks.register('fortifyScan', JavaExec) {
   mainClass = "uk.gov.hmcts.fortifyclient.FortifyClientMainApp"
-  classpath += sourceSets.test.runtimeClasspath
+  classpath += testing.suites.test.get().sources.runtimeClasspath
   jvmArgs = ['--add-opens=java.base/java.lang.reflect=ALL-UNNAMED']
   ignoreExitValue = true
-}
-
-tasks.register('smoke', Test) {
-  description = "Runs Smoke Tests"
-  testClassesDirs = sourceSets.smokeTest.output.classesDirs
-  classpath = sourceSets.smokeTest.runtimeClasspath
 }
 
 checkstyle {
@@ -114,7 +73,7 @@ checkstyle {
 }
 
 jacocoTestReport {
-  executionData(test, integration)
+  executionData(tasks.named('test').get(), tasks.named('integrationTest').get())
   reports {
     xml.required = true
     csv.required = false
@@ -122,21 +81,21 @@ jacocoTestReport {
   }
 }
 
-project.tasks.named('sonarqube') {
+project.tasks.named('sonar') {
   dependsOn jacocoTestReport
 }
 
 project.tasks.named('check') {
-  dependsOn integration
+  dependsOn integrationTest
 }
 
-sonarqube {
+sonar {
   properties {
     property "sonar.organization", "hmcts"
     property "sonar.projectName", "sscs-ccd-case-migration"
     property "sonar.projectKey", "sscs-ccd-case-migration"
     property "sonar.exclusions",
-            """
+      """
             **/exception/*.java,**/hmc/*.java,
             **/domain/*.java,**/common/*.java,
             **/migration/auth/AuthTokenGeneratorConfiguration.java,
@@ -149,36 +108,20 @@ sonarqube {
   }
 }
 
-// before committing a change, make sure task still works
 dependencyUpdates {
   def isNonStable = { String version ->
     def stableKeyword = ['RELEASE', 'FINAL', 'GA'].any { qualifier -> version.toUpperCase().contains(qualifier) }
     def regex = /^[0-9,.v-]+$/
     return !stableKeyword && !(version ==~ regex)
   }
-  rejectVersionIf { selection -> // <---- notice how the closure argument is named
+  rejectVersionIf { selection ->
     return isNonStable(selection.candidate.version) && !isNonStable(selection.currentVersion)
   }
 }
 
 apply from: './gradle/suppress.gradle'
-// https://jeremylong.github.io/DependencyCheck/dependency-check-gradle/configuration.html
 dependencyCheck {
   suppressionFile = 'config/owasp/suppressions.xml'
-}
-
-configurations.configureEach {
-  resolutionStrategy.eachDependency { details ->
-    if (details.requested.group == 'org.junit.platform') {
-      details.useVersion junitPlatform
-    }
-    if (details.requested.group == 'org.junit.jupiter') {
-      details.useVersion junitVersion
-    }
-    if (details.requested.group == 'org.junit.vintage') {
-      details.useVersion junitVersion
-    }
-  }
 }
 
 repositories {
@@ -190,12 +133,10 @@ repositories {
 }
 
 ext {
-  lombokVersion = '1.18.46'
-  junitVersion = '5.14.4'
-  junitPlatform = '1.14.4'
   powermockVersion = '2.0.9'
   springCloudVersion = '2025.0.3'
-  jacksonVersion = '2.22.0'
+  // CVE-2026-54515
+  set('jackson-bom.version', '2.22.0')
   set('log4j2.version', '2.26.1')
   set('commons-lang3.version', '3.20.0')
   set('spring-framework.version', '6.2.19')
@@ -204,13 +145,12 @@ ext {
 
 dependencyManagement {
   imports {
-    mavenBom "org.springframework.boot:spring-boot-dependencies:${springBoot.class.package.implementationVersion}"
     mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
   }
 
   dependencies {
     // CVE-2026-56148, CVE-2026-56149
-    dependency group: 'org.elasticsearch', name: 'elasticsearch', version: '8.19.18'
+    dependency 'org.elasticsearch:elasticsearch:8.19.18'
 
     // CVE-2026-54399, CVE-2026-54428
     dependencySet(group: 'org.apache.httpcomponents.core5', version: '5.4.3') {
@@ -221,58 +161,50 @@ dependencyManagement {
 }
 
 dependencies {
-  implementation group: 'org.springframework.boot', name: 'spring-boot-starter'
-  implementation group: 'org.springframework.boot', name: 'spring-boot-starter-actuator'
-  implementation group: 'org.springframework.boot', name: 'spring-boot-starter-aop'
-  implementation group: 'org.springframework.boot', name: 'spring-boot-starter-json'
-  implementation group: 'org.springframework', name: 'spring-context-support'
-  implementation group: 'org.springframework.retry', name: 'spring-retry'
-  implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-bootstrap'
+  implementation 'org.springframework.boot:spring-boot-starter'
+  implementation 'org.springframework.boot:spring-boot-starter-actuator'
+  implementation 'org.springframework.boot:spring-boot-starter-aop'
+  implementation 'org.springframework.boot:spring-boot-starter-json'
+  implementation 'org.springframework:spring-context-support'
+  implementation 'org.springframework.retry:spring-retry'
+  implementation 'org.springframework.cloud:spring-cloud-starter-bootstrap'
+  implementation 'org.springframework.security:spring-security-oauth2-resource-server'
+  implementation 'org.springframework.security:spring-security-oauth2-client'
+  implementation 'org.springframework.security:spring-security-oauth2-jose'
+  implementation 'org.springframework.security:spring-security-oauth2-core'
+  implementation 'org.springframework.security:spring-security-config'
 
-  implementation group: 'org.springframework.security', name: 'spring-security-oauth2-resource-server'
-  implementation group: 'org.springframework.security', name: 'spring-security-oauth2-client'
-  implementation group: 'org.springframework.security', name: 'spring-security-oauth2-jose'
-  implementation group: 'org.springframework.security', name: 'spring-security-oauth2-core'
-  implementation group: 'org.springframework.security', name: 'spring-security-config'
+  implementation 'com.github.hmcts:idam-java-client:3.0.5'
+  implementation 'com.github.hmcts:service-auth-provider-java-client:5.3.4'
+  implementation 'com.github.hmcts:core-case-data-store-client:5.3.0'
+  implementation 'com.github.hmcts.java-logging:logging:8.0.0'
+  implementation 'com.github.hmcts:sscs-common:6.3.55'
 
-  implementation group: 'com.github.hmcts', name: 'idam-java-client', version: '3.0.5'
-  implementation group: 'com.github.hmcts', name: 'service-auth-provider-java-client', version: '5.3.4'
-  implementation group: 'com.github.hmcts', name: 'core-case-data-store-client', version: '5.3.0'
-  implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: '8.0.0'
-  implementation group: 'com.github.hmcts', name: 'sscs-common', version: '6.3.55'
+  implementation 'org.json:json:20260522'
+  implementation 'io.github.openfeign:feign-jackson:13.6'
+  implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-csv'
+  implementation 'com.fasterxml.jackson.core:jackson-core'
+  implementation 'com.fasterxml.jackson.core:jackson-databind'
+  implementation 'com.fasterxml.jackson.core:jackson-annotations'
+  implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+  implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8'
 
-  implementation group: 'org.json', name: 'json', version: '20260522'
-  implementation group: 'io.github.openfeign', name: 'feign-jackson', version: '13.6'
-  implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-csv', version: jacksonVersion
-  implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: jacksonVersion
-  implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: jacksonVersion
-  implementation group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: '2.22'
-  implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: jacksonVersion
-  implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jdk8', version: jacksonVersion
+  implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.17'
+  implementation 'net.logstash.logback:logstash-logback-encoder:8.1'
+  implementation 'org.apache.commons:commons-fileupload2-jakarta-servlet6:2.0.0-M5'
+  implementation 'commons-io:commons-io:2.22.0'
 
-  implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.8.17'
-  implementation group: 'net.logstash.logback', name: 'logstash-logback-encoder', version: '8.1'
-  implementation group: 'commons-fileupload', name: 'commons-fileupload', version: '1.6.0'
-  implementation group: 'commons-io', name: 'commons-io', version: '2.22.0'
 
-  implementation group: 'org.projectlombok', name: 'lombok', version: lombokVersion
-  annotationProcessor group: 'org.projectlombok', name: 'lombok', version: lombokVersion
-  testAnnotationProcessor group: 'org.projectlombok', name: 'lombok', version: lombokVersion
+  testImplementation 'org.springframework.boot:spring-boot-starter-test'
+  testImplementation 'org.wiremock.integrations:wiremock-spring-boot:3.10.6'
+  testImplementation 'io.rest-assured:rest-assured:5.5.7'
+  testImplementation 'io.rest-assured:xml-path:5.5.7'
+  testImplementation 'io.rest-assured:json-path:5.5.7'
+  testImplementation 'org.mockito:mockito-junit-jupiter'
 
-  testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test'
-  testImplementation group: 'org.wiremock.integrations', name: 'wiremock-spring-boot', version: '3.10.6'
-  testImplementation group: 'io.rest-assured', name: 'rest-assured', version: '5.5.7'
-  testImplementation group: 'io.rest-assured', name: 'xml-path', version: '5.5.7'
-  testImplementation group: 'io.rest-assured', name: 'json-path', version: '5.5.7'
-
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: junitVersion
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: junitVersion
-  testRuntimeOnly group: 'org.junit.vintage', name: 'junit-vintage-engine', version: junitVersion
-  testImplementation group:'org.mockito', name: 'mockito-junit-jupiter', version: '5.23.0'
-  testImplementation group: 'org.powermock', name: 'powermock-api-mockito2', version: powermockVersion
-  testImplementation group: 'org.powermock', name: 'powermock-module-junit4', version: powermockVersion
-
-  testImplementation group: 'com.github.hmcts', name: 'fortify-client', version: '1.4.10', classifier: 'all'
+  testImplementation "org.powermock:powermock-api-mockito2:${powermockVersion}"
+  testImplementation "org.powermock:powermock-module-junit4:${powermockVersion}"
+  testImplementation 'com.github.hmcts:fortify-client:1.4.10:all'
 }
 
 application {
@@ -286,7 +218,7 @@ bootJar {
 }
 
 wrapper {
-    distributionType = Wrapper.DistributionType.ALL
+  distributionType = Wrapper.DistributionType.ALL
 }
 
 configurations.configureEach {
@@ -301,8 +233,6 @@ test {
   environment("AZURE_APPLICATIONINSIGHTS_INSTRUMENTATIONKEY", "some-key")
   systemProperty 'java.locale.providers', 'COMPAT'
 
-  useJUnitPlatform()
-
   testLogging {
     events "failed"
     exceptionFormat "short"
@@ -311,7 +241,6 @@ test {
       events "passed", "started", "skipped", "failed"
       exceptionFormat "full"
     }
-
     info.events = ["failed", "skipped"]
   }
 

--- a/build.gradle
+++ b/build.gradle
@@ -246,7 +246,7 @@ dependencies {
   implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-csv', version: jacksonVersion
   implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: jacksonVersion
   implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: jacksonVersion
-  implementation group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: '2.20'
+  implementation group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: '2.22'
   implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: jacksonVersion
   implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jdk8', version: jacksonVersion
 

--- a/build.gradle
+++ b/build.gradle
@@ -135,6 +135,7 @@ repositories {
 ext {
   powermockVersion = '2.0.9'
   springCloudVersion = '2025.0.3'
+  restassuredVersion = '5.5.7'
   // CVE-2026-54515
   set('jackson-bom.version', '2.21.5')
   set('log4j2.version', '2.26.1')
@@ -197,9 +198,9 @@ dependencies {
 
   testImplementation 'org.springframework.boot:spring-boot-starter-test'
   testImplementation 'org.wiremock.integrations:wiremock-spring-boot:3.10.6'
-  testImplementation 'io.rest-assured:rest-assured:5.5.7'
-  testImplementation 'io.rest-assured:xml-path:5.5.7'
-  testImplementation 'io.rest-assured:json-path:5.5.7'
+  testImplementation "io.rest-assured:rest-assured:${restassuredVersion}"
+  testImplementation "io.rest-assured:xml-path:${restassuredVersion}"
+  testImplementation "io.rest-assured:json-path:${restassuredVersion}"
   testImplementation 'org.mockito:mockito-junit-jupiter'
 
   testImplementation "org.powermock:powermock-api-mockito2:${powermockVersion}"

--- a/build.gradle
+++ b/build.gradle
@@ -7,9 +7,8 @@ plugins {
   id 'io.spring.dependency-management' version '1.1.7'
   id 'org.springframework.boot' version '3.5.16'
   id 'com.github.kt3k.coveralls' version '2.12.2'
-  id 'com.github.ben-manes.versions' version '0.52.0'
-  id 'org.sonarqube' version '4.4.1.3373'
   id 'com.github.ben-manes.versions' version '0.54.0'
+  id 'org.sonarqube' version '7.3.1.8318'
   id 'uk.gov.hmcts.java' version '0.12.70'
   id 'org.owasp.dependencycheck' version '12.1.3'
 }
@@ -242,7 +241,7 @@ dependencies {
   implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: '8.0.0'
   implementation group: 'com.github.hmcts', name: 'sscs-common', version: '6.3.55'
 
-  implementation group: 'org.json', name: 'json', version: '20240303'
+  implementation group: 'org.json', name: 'json', version: '20260522'
   implementation group: 'io.github.openfeign', name: 'feign-jackson', version: '13.6'
   implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-csv', version: jacksonVersion
   implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: jacksonVersion

--- a/build.gradle
+++ b/build.gradle
@@ -81,7 +81,7 @@ jacocoTestReport {
   }
 }
 
-project.tasks.named('sonar') {
+project.tasks.named('sonarqube') {
   dependsOn jacocoTestReport
 }
 
@@ -89,7 +89,7 @@ project.tasks.named('check') {
   dependsOn integrationTest
 }
 
-sonar {
+sonarqube {
   properties {
     property "sonar.organization", "hmcts"
     property "sonar.projectName", "sscs-ccd-case-migration"
@@ -136,7 +136,7 @@ ext {
   powermockVersion = '2.0.9'
   springCloudVersion = '2025.0.3'
   // CVE-2026-54515
-  // set('jackson-bom.version', '2.22.0')
+  set('jackson-bom.version', '2.21.5')
   set('log4j2.version', '2.26.1')
   set('commons-lang3.version', '3.20.0')
   set('spring-framework.version', '6.2.19')

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
   id 'org.springframework.boot' version '3.5.16'
   id 'com.github.kt3k.coveralls' version '2.12.2'
   id 'com.github.ben-manes.versions' version '0.54.0'
-  id 'org.sonarqube' version '7.3.1.8318'
+  id 'org.sonarqube' version '6.2.0.5505'
   id 'uk.gov.hmcts.java' version '0.12.70'
   id 'org.owasp.dependencycheck' version '12.1.3'
 }
@@ -136,7 +136,7 @@ ext {
   powermockVersion = '2.0.9'
   springCloudVersion = '2025.0.3'
   // CVE-2026-54515
-  set('jackson-bom.version', '2.22.0')
+  // set('jackson-bom.version', '2.22.0')
   set('log4j2.version', '2.26.1')
   set('commons-lang3.version', '3.20.0')
   set('spring-framework.version', '6.2.19')

--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ tasks.register('smoke') { dependsOn smokeTest }
 
 tasks.register('fortifyScan', JavaExec) {
   mainClass = "uk.gov.hmcts.fortifyclient.FortifyClientMainApp"
-  classpath += testing.suites.test.get().sources.runtimeClasspath
+  classpath += testing.suites.test.sources.runtimeClasspath
   jvmArgs = ['--add-opens=java.base/java.lang.reflect=ALL-UNNAMED']
   ignoreExitValue = true
 }

--- a/build.gradle
+++ b/build.gradle
@@ -192,7 +192,7 @@ dependencies {
 
   implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.17'
   implementation 'net.logstash.logback:logstash-logback-encoder:8.1'
-  implementation 'org.apache.commons:commons-fileupload:1.6.0'
+  implementation 'commons-fileupload:commons-fileupload:1.6.0'
   implementation 'commons-io:commons-io:2.22.0'
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -207,6 +207,11 @@ dependencyManagement {
     mavenBom "org.springframework.boot:spring-boot-dependencies:${springBoot.class.package.implementationVersion}"
     mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
   }
+
+  dependencies {
+    // CVE-2026-56148, CVE-2026-56149
+    dependency group: 'org.elasticsearch', name: 'elasticsearch', version: '8.19.18'
+  }
 }
 
 dependencies {
@@ -224,7 +229,7 @@ dependencies {
   implementation group: 'org.springframework.security', name: 'spring-security-oauth2-core'
   implementation group: 'org.springframework.security', name: 'spring-security-config'
 
-  implementation group: 'com.github.hmcts', name: 'idam-java-client', version: '3.0.4'
+  implementation group: 'com.github.hmcts', name: 'idam-java-client', version: '3.0.5'
   implementation group: 'com.github.hmcts', name: 'service-auth-provider-java-client', version: '5.3.3'
   implementation group: 'com.github.hmcts', name: 'core-case-data-store-client', version: '5.2.0'
   implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: '8.0.0'

--- a/charts/sscs-ccd-case-migration/Chart.yaml
+++ b/charts/sscs-ccd-case-migration/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for sscs-ccd-case-migration job
 name: sscs-ccd-case-migration
 home: https://github.com/hmcts/sscs-ccd-case-migration
-version: 0.0.24
+version: 0.0.25
 maintainers:
   - name: HMCTS SSCS team
 dependencies:

--- a/charts/sscs-ccd-case-migration/Chart.yaml
+++ b/charts/sscs-ccd-case-migration/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for sscs-ccd-case-migration job
 name: sscs-ccd-case-migration
 home: https://github.com/hmcts/sscs-ccd-case-migration
-version: 0.0.23
+version: 0.0.24
 maintainers:
   - name: HMCTS SSCS team
 dependencies:

--- a/charts/sscs-ccd-case-migration/values.yaml
+++ b/charts/sscs-ccd-case-migration/values.yaml
@@ -50,6 +50,8 @@ job:
           alias: ADD_HEARING_ENCODED_DATA_STRING
         - name: encoded-string-awaiting-confidentiality-req
           alias: AWAITING_CONFIDENTIALITY_REQ_ENCODED_STRING
+        - name: encoded-string-interpreter-language-code-migration
+          alias: INTERPRETER_LANGUAGE_CODE_MIGRATION_ENCODED_STRING
 
   environment:
     IDAM_CLIENT_ID: sscs

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -2,5 +2,7 @@
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
   <suppress until="2026-07-11">
     <cve>CVE-2025-15104</cve>
+    <cve>CVE-2026-54399</cve>
+    <cve>CVE-2026-54428</cve>
   </suppress>
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-  <suppress until="2026-07-11">
+  <suppress until="2026-08-11">
     <cve>CVE-2025-15104</cve>
     <cve>CVE-2026-54399</cve>
     <cve>CVE-2026-54428</cve>

--- a/src/main/java/uk/gov/hmcts/reform/migration/service/migrate/InterpreterLanguageCodeMigration.java
+++ b/src/main/java/uk/gov/hmcts/reform/migration/service/migrate/InterpreterLanguageCodeMigration.java
@@ -24,7 +24,7 @@ public class InterpreterLanguageCodeMigration extends CaseMigrationProcessor {
     static final String INTERPRETER_MIGRATION_EVENT_DESCRIPTION = "Interpreter language code migration";
     static final String LANG_CODE = "code";
     static final List<String> HEARING_OPTIONS_LANG_CODE_PATH =
-        List.of("appeal", "hearingOptions", "languagesList", "values");
+        List.of("appeal", "hearingOptions", "languagesList", "value");
     static final List<String> OVERRIDE_FIELDS_LANG_CODE_PATH =
         List.of("overrideFields", "appellantInterpreter", "interpreterLanguage", "value");
     static final List<String> DEFAULT_LISTING_LANG_CODE_PATH =
@@ -60,19 +60,13 @@ public class InterpreterLanguageCodeMigration extends CaseMigrationProcessor {
         if (nonNull(data)) {
             log.info("Preparing language codes for case {}", caseDetails.getId());
             Map<String, Object> hearingOptionsLang = getParentField(data, HEARING_OPTIONS_LANG_CODE_PATH);
-            String hearingOptionLangCode = hearingOptionsLang != null
-                ? String.valueOf(hearingOptionsLang.get(LANG_CODE))
-                : "";
+            String hearingOptionLangCode = getLangCode(hearingOptionsLang);
 
             Map<String, Object> overrideFieldLang = getParentField(data, OVERRIDE_FIELDS_LANG_CODE_PATH);
-            String overrideFieldLangCode = overrideFieldLang != null
-                ? String.valueOf(overrideFieldLang.get(LANG_CODE))
-                :  "";
+            String overrideFieldLangCode = getLangCode(overrideFieldLang);
 
             Map<String, Object> defaultListingLang = getParentField(data, DEFAULT_LISTING_LANG_CODE_PATH);
-            String defaultListingLangCode = defaultListingLang != null
-                ? String.valueOf(defaultListingLang.get(LANG_CODE))
-                : "";
+            String defaultListingLangCode = getLangCode(defaultListingLang);
 
             if (!LANGUAGE_CODE_MAP.containsKey(hearingOptionLangCode)
                 && !LANGUAGE_CODE_MAP.containsKey(overrideFieldLangCode)
@@ -108,6 +102,7 @@ public class InterpreterLanguageCodeMigration extends CaseMigrationProcessor {
         return INTERPRETER_MIGRATION_EVENT_SUMMARY;
     }
 
+    @SuppressWarnings("unchecked")
     public static Map<String, Object> getParentField(Map<String , Object> root, List<String> path) {
         if (root == null || path == null || path.isEmpty()) {
             log.warn("Root or path not provided to get parent field");
@@ -140,10 +135,15 @@ public class InterpreterLanguageCodeMigration extends CaseMigrationProcessor {
             parentField.put(LANG_CODE, LANGUAGE_CODE_MAP.get(oldLangCode));
             log.info("Updated language code of field {} from \"{}\" to \"{}\"", fieldName, oldLangCode, parentField.get(LANG_CODE));
         } else  {
-            log.warn("Language code for field {} was NOT updated. Field {} language code {} ", fieldName,
-                     parentField != null ? "exists, but " : "doesn't exist and",
-                     oldLangCode.isEmpty() ? "is empty" : "doesn't need to be migrated: " + oldLangCode);
+            log.warn("Language code for field \"{}\" was NOT updated. Parent exists: {}. Current value: \"{}\"",
+                     fieldName,
+                     parentField != null,
+                     oldLangCode.isEmpty() ? "EMPTY" : oldLangCode);
         }
 
+    }
+
+    public String getLangCode(Map<String, Object> parentField) {
+        return (parentField != null && parentField.get(LANG_CODE) != null) ? (String) parentField.get(LANG_CODE) : "";
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/migration/service/migrate/InterpreterLanguageCodeMigration.java
+++ b/src/main/java/uk/gov/hmcts/reform/migration/service/migrate/InterpreterLanguageCodeMigration.java
@@ -21,8 +21,8 @@ import static uk.gov.hmcts.reform.migration.repository.EncodedStringCaseList.fin
 public class InterpreterLanguageCodeMigration extends CaseMigrationProcessor {
 
     static final String INTERPRETER_MIGRATION_EVENT_ID = "migrateCase";
-    static final String INTERPRETER_MIGRATION_EVENT_SUMMARY = "Interpreter language code migration";
-    static final String INTERPRETER_MIGRATION_EVENT_DESCRIPTION = "Interpreter language code migration";
+    static final String INTERPRETER_MIGRATION_EVENT_SUMMARY = "Correct MRD interpreter language code added";
+    static final String INTERPRETER_MIGRATION_EVENT_DESCRIPTION = "Correct MRD interpreter language code added";
     static final String LANG_CODE = "code";
     static final List<String> HEARING_OPTIONS_LANG_CODE_PATH =
         List.of("appeal", "hearingOptions", "languagesList", "value");

--- a/src/main/java/uk/gov/hmcts/reform/migration/service/migrate/InterpreterLanguageCodeMigration.java
+++ b/src/main/java/uk/gov/hmcts/reform/migration/service/migrate/InterpreterLanguageCodeMigration.java
@@ -1,10 +1,5 @@
 package uk.gov.hmcts.reform.migration.service.migrate;
 
-import static java.util.Objects.nonNull;
-import static uk.gov.hmcts.reform.migration.repository.EncodedStringCaseList.findCases;
-
-import java.util.List;
-import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -13,6 +8,12 @@ import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.migration.service.CaseMigrationProcessor;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseDetails;
 import uk.gov.hmcts.reform.sscs.ccd.service.UpdateCcdCaseService;
+
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Objects.nonNull;
+import static uk.gov.hmcts.reform.migration.repository.EncodedStringCaseList.findCases;
 
 @Service
 @Slf4j
@@ -103,7 +104,7 @@ public class InterpreterLanguageCodeMigration extends CaseMigrationProcessor {
     }
 
     @SuppressWarnings("unchecked")
-    public static Map<String, Object> getParentField(Map<String , Object> root, List<String> path) {
+    public static Map<String, Object> getParentField(Map<String, Object> root, List<String> path) {
         if (root == null || path == null || path.isEmpty()) {
             log.warn("Root or path not provided to get parent field");
             return null;
@@ -133,7 +134,8 @@ public class InterpreterLanguageCodeMigration extends CaseMigrationProcessor {
     public void updateLangCode(Map<String, Object> parentField, String oldLangCode, String fieldName) {
         if (parentField != null && LANGUAGE_CODE_MAP.containsKey(oldLangCode)) {
             parentField.put(LANG_CODE, LANGUAGE_CODE_MAP.get(oldLangCode));
-            log.info("Updated language code of field {} from \"{}\" to \"{}\"", fieldName, oldLangCode, parentField.get(LANG_CODE));
+            log.info("Updated language code of field {} from \"{}\" to \"{}\"",
+                     fieldName, oldLangCode, parentField.get(LANG_CODE));
         } else  {
             log.warn("Language code for field \"{}\" was NOT updated. Parent exists: {}. Current value: \"{}\"",
                      fieldName,

--- a/src/main/java/uk/gov/hmcts/reform/migration/service/migrate/InterpreterLanguageCodeMigration.java
+++ b/src/main/java/uk/gov/hmcts/reform/migration/service/migrate/InterpreterLanguageCodeMigration.java
@@ -11,6 +11,7 @@ import uk.gov.hmcts.reform.sscs.ccd.service.UpdateCcdCaseService;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import static java.util.Objects.nonNull;
 import static uk.gov.hmcts.reform.migration.repository.EncodedStringCaseList.findCases;
@@ -30,6 +31,12 @@ public class InterpreterLanguageCodeMigration extends CaseMigrationProcessor {
         List.of("overrideFields", "appellantInterpreter", "interpreterLanguage", "value");
     static final List<String> DEFAULT_LISTING_LANG_CODE_PATH =
         List.of("defaultListingValues", "appellantInterpreter", "interpreterLanguage", "value");
+    static final List<String> HEARING_OPTIONS_LANG_LIST_PARENT_PATH =
+        List.of("appeal", "hearingOptions", "languagesList");
+    static final List<String> OVERRIDE_FIELDS_LANG_LIST_PARENT_PATH =
+        List.of("overrideFields", "appellantInterpreter", "interpreterLanguage");
+    static final List<String> DEFAULT_LISTING_LANG_LIST_PARENT_PATH =
+        List.of("defaultListingValues", "appellantInterpreter", "interpreterLanguage");
     static final Map<String, String> LANGUAGE_CODE_MAP = Map.of(
         "acc-fey", "kur-fey",
         "acc-hki", "zho-hok",
@@ -79,9 +86,19 @@ public class InterpreterLanguageCodeMigration extends CaseMigrationProcessor {
                 throw new RuntimeException(skipMigrationMsg);
             }
 
-            updateLangCode(hearingOptionsLang, hearingOptionLangCode, "languagesList in hearingOptions");
-            updateLangCode(overrideFieldLang, overrideFieldLangCode, "interpreterLanguage in overrideFields");
-            updateLangCode(defaultListingLang, defaultListingLangCode, "interpreterLanguage in defaultListingValues");
+            Map<String, Object> defaultListingLangListParent =
+                getParentField(data, DEFAULT_LISTING_LANG_LIST_PARENT_PATH);
+            Map<String, Object> overrideFieldLangListParent =
+                getParentField(data, OVERRIDE_FIELDS_LANG_LIST_PARENT_PATH);
+            Map<String, Object> hearingOptionLangListParent =
+                getParentField(data, HEARING_OPTIONS_LANG_LIST_PARENT_PATH);
+
+            updateLangCode(hearingOptionsLang,hearingOptionLangListParent,
+                           hearingOptionLangCode, "languagesList in hearingOptions");
+            updateLangCode(overrideFieldLang, overrideFieldLangListParent,
+                           overrideFieldLangCode, "interpreterLanguage in overrideFields");
+            updateLangCode(defaultListingLang, defaultListingLangListParent,
+                           defaultListingLangCode, "interpreterLanguage in defaultListingValues");
         }
 
         log.info("Case {} was updated", caseDetails.getId());
@@ -131,8 +148,14 @@ public class InterpreterLanguageCodeMigration extends CaseMigrationProcessor {
             : null;
     }
 
-    public void updateLangCode(Map<String, Object> parentField, String oldLangCode, String fieldName) {
+    public void updateLangCode(Map<String, Object> parentField, Map<String, Object> langListParent,
+                               String oldLangCode, String fieldName) {
         if (parentField != null && LANGUAGE_CODE_MAP.containsKey(oldLangCode)) {
+            List<Map<String, Object>>  langList = (List<Map<String, Object>>) langListParent.get("list_items");
+            if (langList != null) {
+                langList.stream().filter(lang -> Objects.equals(lang.get(LANG_CODE), oldLangCode))
+                    .forEach(lang -> lang.put(LANG_CODE, LANGUAGE_CODE_MAP.get(oldLangCode)));
+            }
             parentField.put(LANG_CODE, LANGUAGE_CODE_MAP.get(oldLangCode));
             log.info("Updated language code of field {} from \"{}\" to \"{}\"",
                      fieldName, oldLangCode, parentField.get(LANG_CODE));

--- a/src/main/java/uk/gov/hmcts/reform/migration/service/migrate/InterpreterLanguageCodeMigration.java
+++ b/src/main/java/uk/gov/hmcts/reform/migration/service/migrate/InterpreterLanguageCodeMigration.java
@@ -1,0 +1,149 @@
+package uk.gov.hmcts.reform.migration.service.migrate;
+
+import static java.util.Objects.nonNull;
+import static uk.gov.hmcts.reform.migration.repository.EncodedStringCaseList.findCases;
+
+import java.util.List;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+import uk.gov.hmcts.reform.migration.service.CaseMigrationProcessor;
+import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseDetails;
+import uk.gov.hmcts.reform.sscs.ccd.service.UpdateCcdCaseService;
+
+@Service
+@Slf4j
+@ConditionalOnProperty(value = "migration.interpreterLanguageCode.enabled", havingValue = "true")
+public class InterpreterLanguageCodeMigration extends CaseMigrationProcessor {
+
+    static final String INTERPRETER_MIGRATION_EVENT_ID = "migrateCase";
+    static final String INTERPRETER_MIGRATION_EVENT_SUMMARY = "Interpreter language code migration";
+    static final String INTERPRETER_MIGRATION_EVENT_DESCRIPTION = "Interpreter language code migration";
+    static final String LANG_CODE = "code";
+    static final List<String> HEARING_OPTIONS_LANG_CODE_PATH =
+        List.of("appeal", "hearingOptions", "languagesList", "values");
+    static final List<String> OVERRIDE_FIELDS_LANG_CODE_PATH =
+        List.of("overrideFields", "appellantInterpreter", "interpreterLanguage", "value");
+    static final List<String> DEFAULT_LISTING_LANG_CODE_PATH =
+        List.of("defaultListingValues", "appellantInterpreter", "interpreterLanguage", "value");
+    static final Map<String, String> LANGUAGE_CODE_MAP = Map.of(
+        "acc-fey", "kur-fey",
+        "acc-hki", "zho-hok",
+        "acc-kgc", "bnt-kic",
+        "acc-mhh", "ara-mag",
+        "acc-wol", "wol",
+        "alb", "sqi",
+        "cze", "ces",
+        "ger", "deu",
+        "isn", "ish",
+        "phj", "phr"
+    );
+
+    private final String encodedDataString;
+
+    public InterpreterLanguageCodeMigration(@Value("${migration.interpreterLanguageCode.encoded-data-string}")
+                                            String encodedDataString) {
+        this.encodedDataString = encodedDataString;
+    }
+
+    @Override
+    public List<SscsCaseDetails> fetchCasesToMigrate() {
+        return findCases(encodedDataString);
+    }
+
+    @Override
+    public UpdateCcdCaseService.UpdateResult migrate(CaseDetails caseDetails) {
+        Map<String, Object> data = caseDetails.getData();
+        if (nonNull(data)) {
+            log.info("Preparing language codes for case {}", caseDetails.getId());
+            Map<String, Object> hearingOptionsLang = getParentField(data, HEARING_OPTIONS_LANG_CODE_PATH);
+            String hearingOptionLangCode = hearingOptionsLang != null
+                ? String.valueOf(hearingOptionsLang.get(LANG_CODE))
+                : "";
+
+            Map<String, Object> overrideFieldLang = getParentField(data, OVERRIDE_FIELDS_LANG_CODE_PATH);
+            String overrideFieldLangCode = overrideFieldLang != null
+                ? String.valueOf(overrideFieldLang.get(LANG_CODE))
+                :  "";
+
+            Map<String, Object> defaultListingLang = getParentField(data, DEFAULT_LISTING_LANG_CODE_PATH);
+            String defaultListingLangCode = defaultListingLang != null
+                ? String.valueOf(defaultListingLang.get(LANG_CODE))
+                : "";
+
+            if (!LANGUAGE_CODE_MAP.containsKey(hearingOptionLangCode)
+                && !LANGUAGE_CODE_MAP.containsKey(overrideFieldLangCode)
+                && !LANGUAGE_CODE_MAP.containsKey(defaultListingLangCode)) {
+                String skipMigrationMsg = "Skipping case for migration. Language codes are not included in configured "
+                    + "migration codes: hearing options language code = \"" + hearingOptionLangCode
+                    + "\", override fields language code = \"" + overrideFieldLangCode
+                    + "\", default listing language code = \"" + defaultListingLangCode + "\"";
+                throw new RuntimeException(skipMigrationMsg);
+            }
+
+            updateLangCode(hearingOptionsLang, hearingOptionLangCode, "languagesList in hearingOptions");
+            updateLangCode(overrideFieldLang, overrideFieldLangCode, "interpreterLanguage in overrideFields");
+            updateLangCode(defaultListingLang, defaultListingLangCode, "interpreterLanguage in defaultListingValues");
+        }
+
+        log.info("Case {} was updated", caseDetails.getId());
+        return new UpdateCcdCaseService.UpdateResult(getEventSummary(), getEventDescription());
+    }
+
+    @Override
+    public String getEventId() {
+        return INTERPRETER_MIGRATION_EVENT_ID;
+    }
+
+    @Override
+    public String getEventDescription() {
+        return INTERPRETER_MIGRATION_EVENT_DESCRIPTION;
+    }
+
+    @Override
+    public String getEventSummary() {
+        return INTERPRETER_MIGRATION_EVENT_SUMMARY;
+    }
+
+    public static Map<String, Object> getParentField(Map<String , Object> root, List<String> path) {
+        if (root == null || path == null || path.isEmpty()) {
+            log.warn("Root or path not provided to get parent field");
+            return null;
+        }
+
+        Object currentField = root;
+
+        for (String key : path) {
+            if (!(currentField instanceof Map<?, ?> parentField)) {
+                log.warn("Field \"{}\" is not a map on path {}", key, path);
+                return null;
+            }
+
+            currentField = parentField.get(key);
+
+            if (currentField == null) {
+                log.warn("Field \"{}\" doesn't exist on path {}", key,  path);
+                return null;
+            }
+        }
+
+        return currentField instanceof Map<?, ?>
+            ? (Map<String, Object>) currentField
+            : null;
+    }
+
+    public void updateLangCode(Map<String, Object> parentField, String oldLangCode, String fieldName) {
+        if (parentField != null && LANGUAGE_CODE_MAP.containsKey(oldLangCode)) {
+            parentField.put(LANG_CODE, LANGUAGE_CODE_MAP.get(oldLangCode));
+            log.info("Updated language code of field {} from \"{}\" to \"{}\"", fieldName, oldLangCode, parentField.get(LANG_CODE));
+        } else  {
+            log.warn("Language code for field {} was NOT updated. Field {} language code {} ", fieldName,
+                     parentField != null ? "exists, but " : "doesn't exist and",
+                     oldLangCode.isEmpty() ? "is empty" : "doesn't need to be migrated: " + oldLangCode);
+        }
+
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/migration/service/migrate/InterpreterLanguageCodeMigration.java
+++ b/src/main/java/uk/gov/hmcts/reform/migration/service/migrate/InterpreterLanguageCodeMigration.java
@@ -151,10 +151,12 @@ public class InterpreterLanguageCodeMigration extends CaseMigrationProcessor {
     public void updateLangCode(Map<String, Object> parentField, Map<String, Object> langListParent,
                                String oldLangCode, String fieldName) {
         if (parentField != null && LANGUAGE_CODE_MAP.containsKey(oldLangCode)) {
-            List<Map<String, Object>>  langList = (List<Map<String, Object>>) langListParent.get("list_items");
-            if (langList != null) {
-                langList.stream().filter(lang -> Objects.equals(lang.get(LANG_CODE), oldLangCode))
-                    .forEach(lang -> lang.put(LANG_CODE, LANGUAGE_CODE_MAP.get(oldLangCode)));
+            if (nonNull(langListParent)) {
+                List<Map<String, Object>> langList = (List<Map<String, Object>>) langListParent.get("list_items");
+                if (nonNull(langList)) {
+                    langList.stream().filter(lang -> Objects.equals(lang.get(LANG_CODE), oldLangCode))
+                        .forEach(lang -> lang.put(LANG_CODE, LANGUAGE_CODE_MAP.get(oldLangCode)));
+                }
             }
             parentField.put(LANG_CODE, LANGUAGE_CODE_MAP.get(oldLangCode));
             log.info("Updated language code of field {} from \"{}\" to \"{}\"",

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -91,6 +91,9 @@ migration:
   awaitingConfidentialityReq:
     enabled: ${AWAITING_CONFIDENTIALITY_REQ_MIGRATION_ENABLED:false}
     encoded-data-string: ${AWAITING_CONFIDENTIALITY_REQ_ENCODED_STRING:==dummy++encoded--string==}
+  interpreterLanguageCode:
+    enabled: ${INTERPRETER_LANGUAGE_CODE_MIGRATION_ENABLED:false}
+    encoded-data-string: ${INTERPRETER_LANGUAGE_CODE_MIGRATION_ENCODED_STRING:==dummy++encoded--string==}
 
 case-migration:
   elasticsearch.querySize: ${MIGRATION_QUERY_SIZE:10000}

--- a/src/test/java/uk/gov/hmcts/reform/migration/service/migrate/InterpreterLanguageCodeMigrationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/migration/service/migrate/InterpreterLanguageCodeMigrationTest.java
@@ -17,6 +17,7 @@ import uk.gov.hmcts.reform.sscs.ccd.domain.YesNo;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -38,7 +39,8 @@ class InterpreterLanguageCodeMigrationTest {
     private final String albanianMrdCode = "sqi";
     private final String spanishMrdCode = "sqi";
     private final DynamicList albanianLegacy = new DynamicList(
-        new DynamicListItem(albanianLegacyCode, "Albanian"), Collections.emptyList());
+        new DynamicListItem(albanianLegacyCode, "Albanian"),
+        List.of(new DynamicListItem(albanianLegacyCode, "Albanian")));
     private final DynamicList albanianMrd = new DynamicList(
         new DynamicListItem(albanianMrdCode, "Albanian"), Collections.emptyList());
     private final DynamicList spanish = new DynamicList(
@@ -110,6 +112,10 @@ class InterpreterLanguageCodeMigrationTest {
             .getAppellantInterpreter().getInterpreterLanguage().getValue().getCode());
         assertNull(migratedcase.getData().getSchedulingAndListingFields().getDefaultListingValues()
                        .getAppellantInterpreter().getInterpreterLanguage());
+        assertThat(migratedcase.getData().getAppeal().getHearingOptions().getLanguagesList().getListItems()
+                       .stream().noneMatch(lang -> Objects.equals(lang.getCode(), albanianLegacyCode))).isTrue();
+        assertThat(migratedcase.getData().getAppeal().getHearingOptions().getLanguagesList().getListItems()
+                       .stream().anyMatch(lang -> Objects.equals(lang.getCode(), albanianMrdCode))).isTrue();
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/migration/service/migrate/InterpreterLanguageCodeMigrationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/migration/service/migrate/InterpreterLanguageCodeMigrationTest.java
@@ -1,5 +1,23 @@
 package uk.gov.hmcts.reform.migration.service.migrate;
 
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+import uk.gov.hmcts.reform.sscs.ccd.domain.DynamicList;
+import uk.gov.hmcts.reform.sscs.ccd.domain.DynamicListItem;
+import uk.gov.hmcts.reform.sscs.ccd.domain.HearingInterpreter;
+import uk.gov.hmcts.reform.sscs.ccd.domain.HearingOptions;
+import uk.gov.hmcts.reform.sscs.ccd.domain.OverrideFields;
+import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
+import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseDetails;
+import uk.gov.hmcts.reform.sscs.ccd.domain.YesNo;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
 import static java.lang.Long.parseLong;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -11,36 +29,19 @@ import static uk.gov.hmcts.reform.sscs.ccd.util.CaseDataUtils.buildCaseData;
 import static uk.gov.hmcts.reform.sscs.ccd.util.CaseDataUtils.buildCaseDataMap;
 import static uk.gov.hmcts.reform.sscs.ccd.util.CaseDataUtils.convertCaseDetailsToSscsCaseDetails;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import lombok.extern.slf4j.Slf4j;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
-import uk.gov.hmcts.reform.sscs.ccd.domain.DynamicList;
-import uk.gov.hmcts.reform.sscs.ccd.domain.DynamicListItem;
-import uk.gov.hmcts.reform.sscs.ccd.domain.HearingInterpreter;
-import uk.gov.hmcts.reform.sscs.ccd.domain.HearingOptions;
-import uk.gov.hmcts.reform.sscs.ccd.domain.OverrideFields;
-import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
-import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseDetails;
-import uk.gov.hmcts.reform.sscs.ccd.domain.YesNo;
-
 @Slf4j
 class InterpreterLanguageCodeMigrationTest {
     private static final String ENCODED_STRING = "";
     private static final String CASE_REFERENCE = "12332445";
-    private final String ALBANIAN_LEGACY_CODE = "alb";
-    private final String ALBANIAN_MRD_CODE = "sqi";
-    private final String SPANISH_MRD_CODE = "sqi";
-    private final DynamicList ALBANIAN_LEGACY = new DynamicList(
-        new DynamicListItem(ALBANIAN_LEGACY_CODE, "Albanian"), Collections.emptyList());
-    private final DynamicList ALBANIAN_MRD = new DynamicList(
-        new DynamicListItem(ALBANIAN_MRD_CODE, "Albanian"), Collections.emptyList());
-    private final DynamicList SPANISH = new DynamicList(
-        new DynamicListItem(SPANISH_MRD_CODE, "Spanish"), Collections.emptyList());
+    private final String albanianLegacyCode = "alb";
+    private final String albanianMrdCode = "sqi";
+    private final String spanishMrdCode = "sqi";
+    private final DynamicList albanianLegacy = new DynamicList(
+        new DynamicListItem(albanianLegacyCode, "Albanian"), Collections.emptyList());
+    private final DynamicList albanianMrd = new DynamicList(
+        new DynamicListItem(albanianMrdCode, "Albanian"), Collections.emptyList());
+    private final DynamicList spanish = new DynamicList(
+        new DynamicListItem(spanishMrdCode, "Spanish"), Collections.emptyList());
     private InterpreterLanguageCodeMigration interpreterLanguageCodeMigration;
     private CaseDetails caseDetails;
     private SscsCaseData caseData;
@@ -51,8 +52,8 @@ class InterpreterLanguageCodeMigrationTest {
         caseData = buildCaseData();
         caseData.getAppeal()
             .setHearingOptions(HearingOptions.builder()
-                                   .languagesList(ALBANIAN_LEGACY)
-                                   .languages(ALBANIAN_LEGACY.getValue().getLabel())
+                                   .languagesList(albanianLegacy)
+                                   .languages(albanianLegacy.getValue().getLabel())
                                    .wantsSupport("No")
                                    .wantsToAttend("Yes")
                                    .scheduleHearing("No")
@@ -78,12 +79,12 @@ class InterpreterLanguageCodeMigrationTest {
 
     @Test
     @DisplayName("Should migrate to MRD language codes when legacy code is configured")
-    void shouldMigrateToMRDLanguageCodesWhenLegacyCodeIsConfigured() {
+    void shouldMigrateToMrdLanguageCodesWhenLegacyCodeIsConfigured() {
         caseData.getSchedulingAndListingFields()
             .setOverrideFields(OverrideFields.builder()
                                    .duration(75)
                                    .appellantInterpreter(HearingInterpreter.builder()
-                                                             .interpreterLanguage(ALBANIAN_LEGACY)
+                                                             .interpreterLanguage(albanianLegacy)
                                                              .isInterpreterWanted(YesNo.YES)
                                                              .build())
                                    .build());
@@ -101,9 +102,12 @@ class InterpreterLanguageCodeMigrationTest {
 
         SscsCaseDetails migratedcase = convertCaseDetailsToSscsCaseDetails(caseDetails);
 
-        assertEquals(ALBANIAN_MRD_CODE, migratedcase.getData().getAppeal().getHearingOptions().getLanguagesList().getValue().getCode());
-        assertEquals(ALBANIAN_MRD_CODE, migratedcase.getData().getSchedulingAndListingFields().getOverrideFields().getAppellantInterpreter().getInterpreterLanguage().getValue().getCode());
-        assertNull(migratedcase.getData().getSchedulingAndListingFields().getDefaultListingValues().getAppellantInterpreter().getInterpreterLanguage());
+        assertEquals(albanianMrdCode,
+                     migratedcase.getData().getAppeal().getHearingOptions().getLanguagesList().getValue().getCode());
+        assertEquals(albanianMrdCode, migratedcase.getData().getSchedulingAndListingFields().getOverrideFields()
+            .getAppellantInterpreter().getInterpreterLanguage().getValue().getCode());
+        assertNull(migratedcase.getData().getSchedulingAndListingFields().getDefaultListingValues()
+                       .getAppellantInterpreter().getInterpreterLanguage());
     }
 
     @Test
@@ -111,8 +115,8 @@ class InterpreterLanguageCodeMigrationTest {
     void shouldSkipMigrationIfNoneOfLanguagesAreLegacy() {
         caseData.getAppeal()
             .setHearingOptions(HearingOptions.builder()
-                                   .languagesList(ALBANIAN_MRD)
-                                   .languages(ALBANIAN_MRD.getValue().getLabel())
+                                   .languagesList(albanianMrd)
+                                   .languages(albanianMrd.getValue().getLabel())
                                    .wantsSupport("No")
                                    .wantsToAttend("Yes")
                                    .scheduleHearing("No")
@@ -129,21 +133,23 @@ class InterpreterLanguageCodeMigrationTest {
             .setDefaultListingValues(OverrideFields.builder()
                                          .duration(75)
                                          .appellantInterpreter(HearingInterpreter.builder()
-                                                                   .interpreterLanguage(SPANISH)
+                                                                   .interpreterLanguage(spanish)
                                                                    .isInterpreterWanted(YesNo.YES)
                                                                    .build())
                                          .build());
         caseDetails.setData(buildCaseDataMap(caseData));
 
         assertThatThrownBy(() -> interpreterLanguageCodeMigration.migrate(caseDetails))
-                    .hasMessageContaining("Skipping case for migration. Language codes are not included in configured migration codes:");
+            .hasMessageContaining("Skipping case for migration. Language codes are not included in "
+                                      + "configured migration codes:");
     }
 
     @Test
     @DisplayName("Should return parent field")
     void shouldReturnParentField() {
         Map<String, Object> caseDataMap = buildCaseDataMap(caseData);
-        assertEquals(Map.of("code", "alb", "label", "Albanian"), InterpreterLanguageCodeMigration.getParentField(caseDataMap, HEARING_OPTIONS_LANG_CODE_PATH));
+        assertEquals(Map.of("code", "alb", "label", "Albanian"),
+                     InterpreterLanguageCodeMigration.getParentField(caseDataMap, HEARING_OPTIONS_LANG_CODE_PATH));
     }
 
     @Test
@@ -162,6 +168,7 @@ class InterpreterLanguageCodeMigrationTest {
         assertNull(InterpreterLanguageCodeMigration
                        .getParentField(caseDataMap, List.of("defaultListingValues", "appellantInterpreter", "value")));
         assertNull(InterpreterLanguageCodeMigration
-                       .getParentField(Map.of("appeal", Map.of("hearingOptions", "Not HearingOptions")), HEARING_OPTIONS_LANG_CODE_PATH));
+                       .getParentField(Map.of("appeal", Map.of("hearingOptions", "Not HearingOptions")),
+                                       HEARING_OPTIONS_LANG_CODE_PATH));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/migration/service/migrate/InterpreterLanguageCodeMigrationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/migration/service/migrate/InterpreterLanguageCodeMigrationTest.java
@@ -18,12 +18,15 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import static java.lang.Long.parseLong;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static uk.gov.hmcts.reform.migration.repository.EncodedStringCaseListTest.ENCODED_CASE_ID;
+import static uk.gov.hmcts.reform.migration.repository.EncodedStringCaseListTest.ENCODED_STRING;
 import static uk.gov.hmcts.reform.migration.service.migrate.InterpreterLanguageCodeMigration.HEARING_OPTIONS_LANG_CODE_PATH;
 import static uk.gov.hmcts.reform.migration.service.migrate.InterpreterLanguageCodeMigration.INTERPRETER_MIGRATION_EVENT_DESCRIPTION;
+import static uk.gov.hmcts.reform.migration.service.migrate.InterpreterLanguageCodeMigration.INTERPRETER_MIGRATION_EVENT_ID;
 import static uk.gov.hmcts.reform.migration.service.migrate.InterpreterLanguageCodeMigration.INTERPRETER_MIGRATION_EVENT_SUMMARY;
 import static uk.gov.hmcts.reform.sscs.ccd.util.CaseDataUtils.buildCaseData;
 import static uk.gov.hmcts.reform.sscs.ccd.util.CaseDataUtils.buildCaseDataMap;
@@ -31,8 +34,6 @@ import static uk.gov.hmcts.reform.sscs.ccd.util.CaseDataUtils.convertCaseDetails
 
 @Slf4j
 class InterpreterLanguageCodeMigrationTest {
-    private static final String ENCODED_STRING = "";
-    private static final String CASE_REFERENCE = "12332445";
     private final String albanianLegacyCode = "alb";
     private final String albanianMrdCode = "sqi";
     private final String spanishMrdCode = "sqi";
@@ -59,12 +60,13 @@ class InterpreterLanguageCodeMigrationTest {
                                    .scheduleHearing("No")
                                    .languageInterpreter("Yes")
                                    .build());
-        caseDetails = CaseDetails.builder().data(buildCaseDataMap(caseData)).id(parseLong(CASE_REFERENCE)).build();
+        caseDetails = CaseDetails.builder().data(buildCaseDataMap(caseData)).id(1234L).build();
     }
 
     @Test
     @DisplayName("Event details should be correct")
     void shouldReturnCorrectEventDetails() {
+        assertEquals(INTERPRETER_MIGRATION_EVENT_ID, interpreterLanguageCodeMigration.getEventId());
         assertEquals(INTERPRETER_MIGRATION_EVENT_DESCRIPTION, interpreterLanguageCodeMigration.getEventDescription());
         assertEquals(INTERPRETER_MIGRATION_EVENT_SUMMARY, interpreterLanguageCodeMigration.getEventSummary());
     }
@@ -170,5 +172,14 @@ class InterpreterLanguageCodeMigrationTest {
         assertNull(InterpreterLanguageCodeMigration
                        .getParentField(Map.of("appeal", Map.of("hearingOptions", "Not HearingOptions")),
                                        HEARING_OPTIONS_LANG_CODE_PATH));
+    }
+
+    @Test
+    void shouldFetchCasesToMigrate() {
+        var migrationCase = SscsCaseDetails.builder().id(ENCODED_CASE_ID).jurisdiction("SSCS").build();
+        List<SscsCaseDetails> migrationCases = interpreterLanguageCodeMigration.fetchCasesToMigrate();
+
+        assertThat(migrationCases).hasSize(1);
+        assertThat(migrationCases).contains(migrationCase);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/migration/service/migrate/InterpreterLanguageCodeMigrationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/migration/service/migrate/InterpreterLanguageCodeMigrationTest.java
@@ -1,0 +1,167 @@
+package uk.gov.hmcts.reform.migration.service.migrate;
+
+import static java.lang.Long.parseLong;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static uk.gov.hmcts.reform.migration.service.migrate.InterpreterLanguageCodeMigration.HEARING_OPTIONS_LANG_CODE_PATH;
+import static uk.gov.hmcts.reform.migration.service.migrate.InterpreterLanguageCodeMigration.INTERPRETER_MIGRATION_EVENT_DESCRIPTION;
+import static uk.gov.hmcts.reform.migration.service.migrate.InterpreterLanguageCodeMigration.INTERPRETER_MIGRATION_EVENT_SUMMARY;
+import static uk.gov.hmcts.reform.sscs.ccd.util.CaseDataUtils.buildCaseData;
+import static uk.gov.hmcts.reform.sscs.ccd.util.CaseDataUtils.buildCaseDataMap;
+import static uk.gov.hmcts.reform.sscs.ccd.util.CaseDataUtils.convertCaseDetailsToSscsCaseDetails;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+import uk.gov.hmcts.reform.sscs.ccd.domain.DynamicList;
+import uk.gov.hmcts.reform.sscs.ccd.domain.DynamicListItem;
+import uk.gov.hmcts.reform.sscs.ccd.domain.HearingInterpreter;
+import uk.gov.hmcts.reform.sscs.ccd.domain.HearingOptions;
+import uk.gov.hmcts.reform.sscs.ccd.domain.OverrideFields;
+import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
+import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseDetails;
+import uk.gov.hmcts.reform.sscs.ccd.domain.YesNo;
+
+@Slf4j
+class InterpreterLanguageCodeMigrationTest {
+    private static final String ENCODED_STRING = "";
+    private static final String CASE_REFERENCE = "12332445";
+    private final String ALBANIAN_LEGACY_CODE = "alb";
+    private final String ALBANIAN_MRD_CODE = "sqi";
+    private final String SPANISH_MRD_CODE = "sqi";
+    private final DynamicList ALBANIAN_LEGACY = new DynamicList(
+        new DynamicListItem(ALBANIAN_LEGACY_CODE, "Albanian"), Collections.emptyList());
+    private final DynamicList ALBANIAN_MRD = new DynamicList(
+        new DynamicListItem(ALBANIAN_MRD_CODE, "Albanian"), Collections.emptyList());
+    private final DynamicList SPANISH = new DynamicList(
+        new DynamicListItem(SPANISH_MRD_CODE, "Spanish"), Collections.emptyList());
+    private InterpreterLanguageCodeMigration interpreterLanguageCodeMigration;
+    private CaseDetails caseDetails;
+    private SscsCaseData caseData;
+
+    @BeforeEach
+    void setUp() {
+        interpreterLanguageCodeMigration = new InterpreterLanguageCodeMigration(ENCODED_STRING);
+        caseData = buildCaseData();
+        caseData.getAppeal()
+            .setHearingOptions(HearingOptions.builder()
+                                   .languagesList(ALBANIAN_LEGACY)
+                                   .languages(ALBANIAN_LEGACY.getValue().getLabel())
+                                   .wantsSupport("No")
+                                   .wantsToAttend("Yes")
+                                   .scheduleHearing("No")
+                                   .languageInterpreter("Yes")
+                                   .build());
+        caseDetails = CaseDetails.builder().data(buildCaseDataMap(caseData)).id(parseLong(CASE_REFERENCE)).build();
+    }
+
+    @Test
+    @DisplayName("Event details should be correct")
+    void shouldReturnCorrectEventDetails() {
+        assertEquals(INTERPRETER_MIGRATION_EVENT_DESCRIPTION, interpreterLanguageCodeMigration.getEventDescription());
+        assertEquals(INTERPRETER_MIGRATION_EVENT_SUMMARY, interpreterLanguageCodeMigration.getEventSummary());
+    }
+
+    @Test
+    @DisplayName("Should skip migration when data is null")
+    void shouldSkipMigrationWhenDataIsNull() {
+        caseDetails.setData(null);
+        interpreterLanguageCodeMigration.migrate(caseDetails);
+        assertNull(caseDetails.getData());
+    }
+
+    @Test
+    @DisplayName("Should migrate to MRD language codes when legacy code is configured")
+    void shouldMigrateToMRDLanguageCodesWhenLegacyCodeIsConfigured() {
+        caseData.getSchedulingAndListingFields()
+            .setOverrideFields(OverrideFields.builder()
+                                   .duration(75)
+                                   .appellantInterpreter(HearingInterpreter.builder()
+                                                             .interpreterLanguage(ALBANIAN_LEGACY)
+                                                             .isInterpreterWanted(YesNo.YES)
+                                                             .build())
+                                   .build());
+        caseData.getSchedulingAndListingFields()
+            .setDefaultListingValues(OverrideFields.builder()
+                                         .duration(75)
+                                         .appellantInterpreter(HearingInterpreter.builder()
+                                                                   .interpreterLanguage(null)
+                                                                   .isInterpreterWanted(YesNo.NO)
+                                                                   .build())
+                                         .build());
+        caseDetails.setData(buildCaseDataMap(caseData));
+
+        interpreterLanguageCodeMigration.migrate(caseDetails);
+
+        SscsCaseDetails migratedcase = convertCaseDetailsToSscsCaseDetails(caseDetails);
+
+        assertEquals(ALBANIAN_MRD_CODE, migratedcase.getData().getAppeal().getHearingOptions().getLanguagesList().getValue().getCode());
+        assertEquals(ALBANIAN_MRD_CODE, migratedcase.getData().getSchedulingAndListingFields().getOverrideFields().getAppellantInterpreter().getInterpreterLanguage().getValue().getCode());
+        assertNull(migratedcase.getData().getSchedulingAndListingFields().getDefaultListingValues().getAppellantInterpreter().getInterpreterLanguage());
+    }
+
+    @Test
+    @DisplayName("Should skip migration if none of language codes are legacy")
+    void shouldSkipMigrationIfNoneOfLanguagesAreLegacy() {
+        caseData.getAppeal()
+            .setHearingOptions(HearingOptions.builder()
+                                   .languagesList(ALBANIAN_MRD)
+                                   .languages(ALBANIAN_MRD.getValue().getLabel())
+                                   .wantsSupport("No")
+                                   .wantsToAttend("Yes")
+                                   .scheduleHearing("No")
+                                   .languageInterpreter("Yes")
+                                   .build());
+        caseData.getSchedulingAndListingFields()
+            .setOverrideFields(OverrideFields.builder()
+                                   .duration(75)
+                                   .appellantInterpreter(HearingInterpreter.builder()
+                                                             .interpreterLanguage(null)
+                                                             .build())
+                                   .build());
+        caseData.getSchedulingAndListingFields()
+            .setDefaultListingValues(OverrideFields.builder()
+                                         .duration(75)
+                                         .appellantInterpreter(HearingInterpreter.builder()
+                                                                   .interpreterLanguage(SPANISH)
+                                                                   .isInterpreterWanted(YesNo.YES)
+                                                                   .build())
+                                         .build());
+        caseDetails.setData(buildCaseDataMap(caseData));
+
+        assertThatThrownBy(() -> interpreterLanguageCodeMigration.migrate(caseDetails))
+                    .hasMessageContaining("Skipping case for migration. Language codes are not included in configured migration codes:");
+    }
+
+    @Test
+    @DisplayName("Should return parent field")
+    void shouldReturnParentField() {
+        Map<String, Object> caseDataMap = buildCaseDataMap(caseData);
+        assertEquals(Map.of("code", "alb", "label", "Albanian"), InterpreterLanguageCodeMigration.getParentField(caseDataMap, HEARING_OPTIONS_LANG_CODE_PATH));
+    }
+
+    @Test
+    @DisplayName("Should return null when root or path to parent field is empty")
+    void shouldReturnNullWhenRootOrPathToParentFieldIsEmpty() {
+        Map<String, Object> caseDataMap = buildCaseDataMap(caseData);
+        assertNull(InterpreterLanguageCodeMigration.getParentField(null, HEARING_OPTIONS_LANG_CODE_PATH));
+        assertNull(InterpreterLanguageCodeMigration.getParentField(caseDataMap, null));
+        assertNull(InterpreterLanguageCodeMigration.getParentField(caseDataMap, List.of()));
+    }
+
+    @Test
+    @DisplayName("Should return null when path to parent field is broken")
+    void shouldReturnNullWhenPathToParentFieldIsBroken() {
+        Map<String, Object> caseDataMap = buildCaseDataMap(caseData);
+        assertNull(InterpreterLanguageCodeMigration
+                       .getParentField(caseDataMap, List.of("defaultListingValues", "appellantInterpreter", "value")));
+        assertNull(InterpreterLanguageCodeMigration
+                       .getParentField(Map.of("appeal", Map.of("hearingOptions", "Not HearingOptions")), HEARING_OPTIONS_LANG_CODE_PATH));
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

See [SSCSCI-2665](https://tools.hmcts.net/jira/browse/SSCSCI-2665)

### Change description ###

Created Interpreter language migration. Will update language codes in 3 fields in case data if the codes are in the configured language code map

`build.gradle` update includes removing legacy boilerplate code and library updates.

| Name | Change |
| --- | --- |
| [io.freefair.lombok](https://docs.freefair.io/gradle-plugins/9.5.0/reference/) | `8.14.2` -> `8.14.4` |
| [org.springframework.boot](https://spring.io/projects/spring-boot) | `3.5.14` -> `3.5.16` |
| [com.github.ben-manes.versions](https://github.com/ben-manes/gradle-versions-plugin) | `0.52.0` -> `0.54.0` |
| [org.sonarqube](http://redirect.sonarsource.com/doc/gradle.html) | `4.4.1.3373` -> `5.1.0.4882` |
| [checkstyle](https://docs.gradle.org/current/userguide/checkstyle_plugin.html) | `11.0.1` -> `13.7.0` |
| [log4j2](https://logging.apache.org/log4j/2.x/) | `2.26.0` -> `2.26.1` |
| [org.springframework.cloud](https://spring.io/projects/spring-cloud) | `2025.0.0` -> `2025.0.3` |
| [idam-java-client](https://github.com/hmcts/idam-java-client) | `3.0.4` -> `3.0.5` |
| [service-auth-provider-java-client](https://github.com/hmcts/service-auth-provider-java-client) | `5.3.3` -> `5.3.4` |
| [core-case-data-store-client](https://github.com/hmcts/ccd-client) | `5.2.0` -> `5.3.0` |
| https://github.com/douglascrockford/JSON-java | `20240303` -> `20260522` |
| [org.springdoc](https://springdoc.org/) | `2.8.13` -> `2.8.17` |
| [commons-io](https://commons.apache.org/proper/commons-io/) | `2.20.0` -> `2.22.0` |
| [io.rest-assured](https://rest-assured.io/) | `5.5.6` -> `5.5.7` |

Removed org.projectlombok:lombok from dependencies as the io.freefair.lombok plugin completely automates adding Lombok annotations, processors, and dependencies.

Removed hardcoded versions of dependencies that are managed by Spring to keep it automated as long as no vulnerabilities are flagged for these dependencies. 

Replaced manual Source Sets with the testing block to reduce boilerplate code. The new test suites create tasks automatically named functionalTest, integrationTest. I used simple task aliases for the tests so the pipeline commands won't break.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
