### PR TITLE
SSCSCI: dependency issue fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -211,6 +211,12 @@ dependencyManagement {
   dependencies {
     // CVE-2026-56148, CVE-2026-56149
     dependency group: 'org.elasticsearch', name: 'elasticsearch', version: '8.19.18'
+
+    // CVE-2026-54399, CVE-2026-54428
+    dependencySet(group: 'org.apache.httpcomponents.core5', version: '5.4.3') {
+      entry 'httpcore5'
+      entry 'httpcore5-h2'
+    }
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -207,6 +207,11 @@ dependencyManagement {
     mavenBom "org.springframework.boot:spring-boot-dependencies:${springBoot.class.package.implementationVersion}"
     mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
   }
+
+  dependencies {
+    // CVE-2026-56148, CVE-2026-56149
+    dependency group: 'org.elasticsearch', name: 'elasticsearch', version: '8.19.18'
+  }
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -195,7 +195,8 @@ ext {
   junitPlatform = '1.13.4'
   powermockVersion = '2.0.9'
   springCloudVersion = '2025.0.0'
-  jacksonVersion = '2.20.0'
+  // CVE-2026-54515
+  set('jackson-bom.version', '2.21.5')
   set('log4j2.version', '2.26.0')
   set('commons-lang3.version', '3.20.0')
   set('spring-framework.version', '6.2.19')
@@ -243,12 +244,12 @@ dependencies {
 
   implementation group: 'org.json', name: 'json', version: '20240303'
   implementation group: 'io.github.openfeign', name: 'feign-jackson', version: '13.6'
-  implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-csv', version: jacksonVersion
-  implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: jacksonVersion
-  implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: jacksonVersion
-  implementation group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: '2.20'
-  implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: jacksonVersion
-  implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jdk8', version: jacksonVersion
+  implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-csv'
+  implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core'
+  implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind'
+  implementation group: 'com.fasterxml.jackson.core', name: 'jackson-annotations'
+  implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310'
+  implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jdk8'
 
   implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.8.13'
   implementation group: 'net.logstash.logback', name: 'logstash-logback-encoder', version: '8.1'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -2,5 +2,7 @@
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
   <suppress until="2026-07-11">
     <cve>CVE-2025-15104</cve>
+    <cve>CVE-2026-54399</cve>
+    <cve>CVE-2026-54428</cve>
   </suppress>
 </suppressions>


### PR DESCRIPTION
### Change description ###

| Name | Change |
| --- | --- |
| [com.fasterxml.jackson](https://github.com/FasterXML/jackson) | `2.20.0` -> `2.21.5` |
| [org.elasticsearch](https://github.com/elastic/elasticsearch) | `8.19.10` -> `8.19.18` |
| [org.apache.httpcomponents.core5](https://hc.apache.org/httpcomponents-core-ga/) | `5.3.6` -> `5.4.3` |

Also suppressing CVE-2026-54399 and CVE-2026-54428 due to version 4 of [org.apache.httpcomponents](https://mvnrepository.com/artifact/org.apache.httpcomponents/httpcore). V4 is a different Maven artifact while the vulnerabilities are only on v5, therefore it's a false positive.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
