### PR TITLE
SSCSCI-2693: Sent to FTA migration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -150,8 +150,8 @@ dependencyManagement {
   }
 
   dependencies {
-    // CVE-2026-56148, CVE-2026-56149
-    dependency 'org.elasticsearch:elasticsearch:8.19.18'
+    // CVE-2026-63144, CVE-2026-63263
+    dependency 'org.elasticsearch:elasticsearch:8.19.19'
 
     // CVE-2026-54399, CVE-2026-54428
     dependencySet(group: 'org.apache.httpcomponents.core5', version: '5.4.3') {

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
   <suppress until="2026-08-13">
+    <cve>CVE-2025-15104</cve>
     <cve>CVE-2026-54399</cve>
     <cve>CVE-2026-54428</cve>
   </suppress>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
   <suppress until="2026-08-13">
-    <cve>CVE-2025-15104</cve>
     <cve>CVE-2026-54399</cve>
     <cve>CVE-2026-54428</cve>
   </suppress>

--- a/src/main/java/uk/gov/hmcts/reform/migration/service/migrate/SentToDwpMigration.java
+++ b/src/main/java/uk/gov/hmcts/reform/migration/service/migrate/SentToDwpMigration.java
@@ -23,7 +23,7 @@ import static uk.gov.hmcts.reform.sscs.ccd.service.UpdateCcdCaseService.UpdateRe
 @ConditionalOnProperty(value = "migration.sentToDwpMigration.enabled", havingValue = "true")
 public class SentToDwpMigration extends CaseMigrationProcessor {
 
-    public static final String SENT_TO_DWP_MIGRATION_EVENT_ID = "migrateCase";
+    public static final String SENT_TO_DWP_MIGRATION_EVENT_ID = "sentToDwp";
     public static final String SENT_TO_DWP_MIGRATION_EVENT_SUMMARY = "Migrate case for Sent to FTA";
     public static final String SENT_TO_DWP_MIGRATION_EVENT_DESCRIPTION = "Migrate case for Sent to FTA";
     public static final String HMCTS_DWP_STATE = "hmctsDwpState";

--- a/src/main/java/uk/gov/hmcts/reform/migration/service/migrate/SentToDwpMigration.java
+++ b/src/main/java/uk/gov/hmcts/reform/migration/service/migrate/SentToDwpMigration.java
@@ -1,12 +1,6 @@
 package uk.gov.hmcts.reform.migration.service.migrate;
 
-import static java.util.Objects.isNull;
-import static uk.gov.hmcts.reform.migration.repository.EncodedStringCaseList.findCases;
-import static uk.gov.hmcts.reform.sscs.ccd.service.UpdateCcdCaseService.*;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.time.LocalDate;
-import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -16,6 +10,13 @@ import uk.gov.hmcts.reform.migration.service.CaseMigrationProcessor;
 import uk.gov.hmcts.reform.sscs.ccd.domain.Benefit;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseDetails;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static java.util.Objects.isNull;
+import static uk.gov.hmcts.reform.migration.repository.EncodedStringCaseList.findCases;
+import static uk.gov.hmcts.reform.sscs.ccd.service.UpdateCcdCaseService.UpdateResult;
 
 @Service
 @Slf4j
@@ -63,7 +64,8 @@ public class SentToDwpMigration extends CaseMigrationProcessor {
                 }
 
             } else {
-                throw new RuntimeException("Skipping case for migration due to " + DATE_SENT_TO_DWP + " is already set.");
+                throw new RuntimeException("Skipping case for migration due to " + DATE_SENT_TO_DWP
+                                               + " is already set");
             }
         } else {
             throw new RuntimeException("Skipping case for migration due to case data is empty.");

--- a/src/main/java/uk/gov/hmcts/reform/migration/service/migrate/SentToDwpMigration.java
+++ b/src/main/java/uk/gov/hmcts/reform/migration/service/migrate/SentToDwpMigration.java
@@ -60,7 +60,7 @@ public class SentToDwpMigration extends CaseMigrationProcessor {
                 if (isNull(data.get(HMCTS_DWP_STATE))) {
                     data.put(HMCTS_DWP_STATE, SENT_TO_DWP);
                 } else {
-                    log.info("{} is already set for case {}", HMCTS_DWP_STATE, sscsCaseData.getCcdCaseId());
+                    log.info("{} is already set for case {}", HMCTS_DWP_STATE, sscsCaseData.getCaseReference());
                 }
 
             } else {

--- a/src/main/java/uk/gov/hmcts/reform/migration/service/migrate/SentToDwpMigration.java
+++ b/src/main/java/uk/gov/hmcts/reform/migration/service/migrate/SentToDwpMigration.java
@@ -1,0 +1,105 @@
+package uk.gov.hmcts.reform.migration.service.migrate;
+
+import static java.util.Objects.isNull;
+import static uk.gov.hmcts.reform.migration.repository.EncodedStringCaseList.findCases;
+import static uk.gov.hmcts.reform.sscs.ccd.service.UpdateCcdCaseService.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+import uk.gov.hmcts.reform.migration.service.CaseMigrationProcessor;
+import uk.gov.hmcts.reform.sscs.ccd.domain.Benefit;
+import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
+import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseDetails;
+
+@Service
+@Slf4j
+@ConditionalOnProperty(value = "migration.sentToDwpMigration.enabled", havingValue = "true")
+public class SentToDwpMigration extends CaseMigrationProcessor {
+
+    public static final String SENT_TO_DWP_MIGRATION_EVENT_ID = "migrateCase";
+    public static final String SENT_TO_DWP_MIGRATION_EVENT_SUMMARY = "Migrate case for Sent to FTA";
+    public static final String SENT_TO_DWP_MIGRATION_EVENT_DESCRIPTION = "Migrate case for Sent to FTA";
+    public static final String HMCTS_DWP_STATE = "hmctsDwpState";
+    public static final String SENT_TO_DWP = "sentToDwp";
+    public static final String DATE_SENT_TO_DWP = "dateSentToDwp";
+
+    private final ObjectMapper objectMapper;
+    private final String encodedDataString;
+    private final int dwpResponseDueDays;
+    private final int dwpResponseDueDaysChildSupport;
+
+    public SentToDwpMigration(@Value("${migration.sentToDwpMigration.encoded-string}") String encodedDataString,
+                              @Value("${dwp.response.due.days}") int dwpResponseDueDays,
+                              @Value("${dwp.response.due.days-child-support}") int dwpResponseDueDaysChildSupport) {
+        this.objectMapper = new ObjectMapper().findAndRegisterModules();
+        this.encodedDataString = encodedDataString;
+        this.dwpResponseDueDays = dwpResponseDueDays;
+        this.dwpResponseDueDaysChildSupport = dwpResponseDueDaysChildSupport;
+    }
+
+    @Override
+    public List<SscsCaseDetails> fetchCasesToMigrate() {
+        return findCases(encodedDataString);
+    }
+
+    @Override
+    public UpdateResult migrate(CaseDetails caseDetails) {
+        var data = caseDetails.getData();
+        if (data != null) {
+            SscsCaseData sscsCaseData = objectMapper.convertValue(data, SscsCaseData.class);
+
+            if (isNull(data.get(DATE_SENT_TO_DWP))) {
+                data.put(DATE_SENT_TO_DWP,calculateSentToDwpDate(sscsCaseData));
+                if (isNull(data.get(HMCTS_DWP_STATE))) {
+                    data.put(HMCTS_DWP_STATE, SENT_TO_DWP);
+                } else {
+                    log.info("{} is already set for case {}", HMCTS_DWP_STATE, sscsCaseData.getCcdCaseId());
+                }
+
+            } else {
+                throw new RuntimeException("Skipping case for migration due to " + DATE_SENT_TO_DWP + " is already set.");
+            }
+        } else {
+            throw new RuntimeException("Skipping case for migration due to case data is empty.");
+        }
+
+        return new UpdateResult(getEventSummary(), getEventDescription());
+    }
+
+    @Override
+    public String getEventId() {
+        return SENT_TO_DWP_MIGRATION_EVENT_ID;
+    }
+
+    @Override
+    public String getEventDescription() {
+        return SENT_TO_DWP_MIGRATION_EVENT_DESCRIPTION;
+    }
+
+    @Override
+    public String getEventSummary() {
+        return SENT_TO_DWP_MIGRATION_EVENT_SUMMARY;
+    }
+
+    private int getResponseDueDays(SscsCaseData caseData) {
+        return caseData.getAppeal().getBenefitType() != null
+            && Benefit.CHILD_SUPPORT.getShortName().equalsIgnoreCase(caseData.getAppeal().getBenefitType().getCode())
+            ? dwpResponseDueDaysChildSupport : dwpResponseDueDays;
+    }
+
+    private String calculateSentToDwpDate(SscsCaseData caseData) {
+        int numberOfDays = getResponseDueDays(caseData);
+        if (isNull(caseData.getDwpDueDate())) {
+            throw new RuntimeException("Skipping migration due to FTA response due date is empty");
+        }
+
+        LocalDate dwpDueDate = LocalDate.parse(caseData.getDwpDueDate());
+        return dwpDueDate.minusDays(numberOfDays).toString();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/migration/service/migrate/SentToDwpMigration.java
+++ b/src/main/java/uk/gov/hmcts/reform/migration/service/migrate/SentToDwpMigration.java
@@ -57,12 +57,7 @@ public class SentToDwpMigration extends CaseMigrationProcessor {
 
             if (isNull(data.get(DATE_SENT_TO_DWP))) {
                 data.put(DATE_SENT_TO_DWP,calculateSentToDwpDate(sscsCaseData));
-                if (isNull(data.get(HMCTS_DWP_STATE))) {
-                    data.put(HMCTS_DWP_STATE, SENT_TO_DWP);
-                } else {
-                    log.info("{} is already set for case {}", HMCTS_DWP_STATE, caseDetails.getId());
-                }
-
+                data.put(HMCTS_DWP_STATE, SENT_TO_DWP);
             } else {
                 throw new RuntimeException("Skipping case for migration due to " + DATE_SENT_TO_DWP
                                                + " is already set");

--- a/src/main/java/uk/gov/hmcts/reform/migration/service/migrate/SentToDwpMigration.java
+++ b/src/main/java/uk/gov/hmcts/reform/migration/service/migrate/SentToDwpMigration.java
@@ -60,7 +60,7 @@ public class SentToDwpMigration extends CaseMigrationProcessor {
                 if (isNull(data.get(HMCTS_DWP_STATE))) {
                     data.put(HMCTS_DWP_STATE, SENT_TO_DWP);
                 } else {
-                    log.info("{} is already set for case {}", HMCTS_DWP_STATE, sscsCaseData.getCaseReference());
+                    log.info("{} is already set for case {}", HMCTS_DWP_STATE, caseDetails.getId());
                 }
 
             } else {

--- a/src/main/java/uk/gov/hmcts/reform/migration/service/migrate/SentToDwpMigration.java
+++ b/src/main/java/uk/gov/hmcts/reform/migration/service/migrate/SentToDwpMigration.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.migration.service.migrate;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.temporal.ChronoUnit;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -29,6 +30,7 @@ public class SentToDwpMigration extends CaseMigrationProcessor {
     public static final String HMCTS_DWP_STATE = "hmctsDwpState";
     public static final String SENT_TO_DWP = "sentToDwp";
     public static final String DATE_SENT_TO_DWP = "dateSentToDwp";
+    public static final String DWP_DUE_DATE = "dwpDueDate";
 
     private final ObjectMapper objectMapper;
     private final String encodedDataString;
@@ -54,13 +56,16 @@ public class SentToDwpMigration extends CaseMigrationProcessor {
         var data = caseDetails.getData();
         if (data != null) {
             SscsCaseData sscsCaseData = objectMapper.convertValue(data, SscsCaseData.class);
+            if (isNull(data.get(DWP_DUE_DATE))) {
+                throw new RuntimeException("Skipping migration as FTA response due date is empty");
+            }
 
-            if (isNull(data.get(DATE_SENT_TO_DWP))) {
-                data.put(DATE_SENT_TO_DWP,calculateSentToDwpDate(sscsCaseData));
+            if (shouldMigrate(sscsCaseData, caseDetails.getId().toString())) {
+                data.put(DATE_SENT_TO_DWP, calculateSentToDwpDate(sscsCaseData));
                 data.put(HMCTS_DWP_STATE, SENT_TO_DWP);
             } else {
                 throw new RuntimeException("Skipping case for migration due to " + DATE_SENT_TO_DWP
-                                               + " is already set");
+                                               + " is correct");
             }
         } else {
             throw new RuntimeException("Skipping case for migration due to case data is empty.");
@@ -92,11 +97,22 @@ public class SentToDwpMigration extends CaseMigrationProcessor {
 
     private String calculateSentToDwpDate(SscsCaseData caseData) {
         int numberOfDays = getResponseDueDays(caseData);
-        if (isNull(caseData.getDwpDueDate())) {
-            throw new RuntimeException("Skipping migration due to FTA response due date is empty");
-        }
-
         LocalDate dwpDueDate = LocalDate.parse(caseData.getDwpDueDate());
         return dwpDueDate.minusDays(numberOfDays).toString();
+    }
+
+    private boolean shouldMigrate(SscsCaseData caseData, String caseReference) {
+        if (isNull(caseData.getDateSentToDwp())) {
+            log.info("Date evidence sent to FTA is not set for case {}", caseReference);
+            return true;
+        }
+
+        int expectedDifferenceInDays = getResponseDueDays(caseData);
+        LocalDate dwpDueDate = LocalDate.parse(caseData.getDwpDueDate());
+        LocalDate sentToFtaDate = LocalDate.parse(caseData.getDateSentToDwp());
+        long differenceInDays = ChronoUnit.DAYS.between(sentToFtaDate, dwpDueDate);
+        log.info("Difference in days between dwpDueDate and dateSentToDwp: {} for case {}",
+                 differenceInDays, caseReference);
+        return differenceInDays != expectedDifferenceInDays;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/migration/service/migrate/SentToDwpMigration.java
+++ b/src/main/java/uk/gov/hmcts/reform/migration/service/migrate/SentToDwpMigration.java
@@ -25,8 +25,8 @@ import static uk.gov.hmcts.reform.sscs.ccd.service.UpdateCcdCaseService.UpdateRe
 public class SentToDwpMigration extends CaseMigrationProcessor {
 
     public static final String SENT_TO_DWP_MIGRATION_EVENT_ID = "sentToDwp";
-    public static final String SENT_TO_DWP_MIGRATION_EVENT_SUMMARY = "Migrate case for Sent to FTA";
-    public static final String SENT_TO_DWP_MIGRATION_EVENT_DESCRIPTION = "Migrate case for Sent to FTA";
+    public static final String SENT_TO_DWP_MIGRATION_EVENT_SUMMARY = "To update data fields in Appeal details tab";
+    public static final String SENT_TO_DWP_MIGRATION_EVENT_DESCRIPTION = "To update data fields in Appeal details tab";
     public static final String HMCTS_DWP_STATE = "hmctsDwpState";
     public static final String SENT_TO_DWP = "sentToDwp";
     public static final String DATE_SENT_TO_DWP = "dateSentToDwp";

--- a/src/main/java/uk/gov/hmcts/reform/migration/service/migrate/SentToDwpMigration.java
+++ b/src/main/java/uk/gov/hmcts/reform/migration/service/migrate/SentToDwpMigration.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.reform.migration.service.migrate;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.time.temporal.ChronoUnit;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -13,6 +12,7 @@ import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseDetails;
 
 import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 import static java.util.Objects.isNull;

--- a/src/main/java/uk/gov/hmcts/reform/migration/service/migrate/SentToDwpMigration.java
+++ b/src/main/java/uk/gov/hmcts/reform/migration/service/migrate/SentToDwpMigration.java
@@ -24,7 +24,7 @@ import static uk.gov.hmcts.reform.sscs.ccd.service.UpdateCcdCaseService.UpdateRe
 @ConditionalOnProperty(value = "migration.sentToDwpMigration.enabled", havingValue = "true")
 public class SentToDwpMigration extends CaseMigrationProcessor {
 
-    public static final String SENT_TO_DWP_MIGRATION_EVENT_ID = "sentToDwp";
+    public static final String SENT_TO_DWP_MIGRATION_EVENT_ID = "migrateCase";
     public static final String SENT_TO_DWP_MIGRATION_EVENT_SUMMARY = "To update data fields in Appeal details tab";
     public static final String SENT_TO_DWP_MIGRATION_EVENT_DESCRIPTION = "To update data fields in Appeal details tab";
     public static final String HMCTS_DWP_STATE = "hmctsDwpState";

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -57,7 +57,7 @@ migration:
     encoded-data-string: ${COMPLETED_HEARINGS_OUTCOMES_ENCODED_DATA_STRING:==dummy++encoded--string==}
   confidentialityFlag:
     enabled: ${CONFIDENTIALITY_FLAG_MIGRATION_ENABLED:false}
-    encoded-data-string: ${CONFIDENTIALITY_FLAG_ENCODED_STRING:==dummy++encoded--string==}  
+    encoded-data-string: ${CONFIDENTIALITY_FLAG_ENCODED_STRING:==dummy++encoded--string==}
   defaultPanelComposition:
     enabled: ${DEFAULT_PANEL_COMPOSITION_ENABLED:false}
     use-pre-fetched-case-list: ${ULR_USE_PRE_FETCHED_CASE_LIST:false}
@@ -88,6 +88,9 @@ migration:
   rpc:
     enabled: ${RPC_MIGRATION_ENABLED:false}
     encoded-string: ${RPC_MIGRATION_ENCODED_STRING:==dummy++encoded--string==}
+  sentToDwpMigration:
+    enabled: ${SENT_TO_DWP_MIGRATION_ENABLED:false}
+    encoded-string: ${SENT_TO_DWP_MIGRATION_ENCODED_STRING:==dummy++encoded--string==}
   updateListingReqsMissingAmendReason:
     enabled: ${UPDATE_LISTING_REQS_MISSING_AMEND_REASON:false}
     encoded-data-string: ${UPDATE_LISTING_REQS_MISSING_AMEND_REASON_ENCODED_STRING:==dummy++encoded--string==}
@@ -112,4 +115,8 @@ judicial-ref.api.url: ${JUDICIAL_REF_API_URL:http://localhost:8084}
 feature.elinksV2.enabled: ${ELINKS_V2_FEATURE_ENABLED:false}
 hmc.url: ${HMC_API_URL:http://localhost:8084}
 
-
+dwp:
+  response:
+    due:
+      days: ${DWP_RESPONSE_DUE_DAYS:28}
+      days-child-support: ${DWP_RESPONSE_DUE_DAYS_CHILD_SUPPORT:42}

--- a/src/test/java/uk/gov/hmcts/reform/migration/service/migrate/SentToDwpMigrationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/migration/service/migrate/SentToDwpMigrationTest.java
@@ -1,0 +1,123 @@
+package uk.gov.hmcts.reform.migration.service.migrate;
+
+import java.time.LocalDate;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+import uk.gov.hmcts.reform.sscs.ccd.domain.BenefitType;
+import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
+
+import java.util.List;
+import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseDetails;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static uk.gov.hmcts.reform.migration.repository.EncodedStringCaseListTest.ENCODED_CASE_ID;
+import static uk.gov.hmcts.reform.migration.repository.EncodedStringCaseListTest.ENCODED_STRING;
+import static uk.gov.hmcts.reform.migration.service.migrate.SentToDwpMigration.DATE_SENT_TO_DWP;
+import static uk.gov.hmcts.reform.migration.service.migrate.SentToDwpMigration.HMCTS_DWP_STATE;
+import static uk.gov.hmcts.reform.migration.service.migrate.SentToDwpMigration.SENT_TO_DWP_MIGRATION_EVENT_DESCRIPTION;
+import static uk.gov.hmcts.reform.migration.service.migrate.SentToDwpMigration.SENT_TO_DWP_MIGRATION_EVENT_ID;
+import static uk.gov.hmcts.reform.migration.service.migrate.SentToDwpMigration.SENT_TO_DWP_MIGRATION_EVENT_SUMMARY;
+import static uk.gov.hmcts.reform.sscs.ccd.util.CaseDataUtils.buildCaseData;
+import static uk.gov.hmcts.reform.sscs.ccd.util.CaseDataUtils.buildCaseDataMap;
+
+class SentToDwpMigrationTest {
+
+    private static final int RESPONSE_DUE_DAYS = 28;
+    private static final int RESPONSE_DUE_DAYS_CM = 42;
+
+    private SentToDwpMigration sentToDwpMigration;
+    private CaseDetails caseDetails;
+    private SscsCaseData sscsCaseData;
+
+    @BeforeEach
+    void setUp() {
+        sentToDwpMigration = new SentToDwpMigration(ENCODED_STRING, RESPONSE_DUE_DAYS, RESPONSE_DUE_DAYS_CM);
+        sscsCaseData = buildCaseData("test", "childSupport", "Child Support");
+    }
+
+    @Test
+    @DisplayName("Should fetch cases from encoded string to migrate")
+    void shouldFetchCasesToMigrate() {
+        var migrationCase = SscsCaseDetails.builder().id(ENCODED_CASE_ID).jurisdiction("SSCS").build();
+        List<SscsCaseDetails> migrationCases = sentToDwpMigration.fetchCasesToMigrate();
+
+        assertThat(migrationCases).hasSize(1);
+        assertThat(migrationCases).contains(migrationCase);
+    }
+
+    @Test
+    @DisplayName("Event details should be correct")
+    void shouldReturnCorrectEventDetails() {
+        assertEquals(SENT_TO_DWP_MIGRATION_EVENT_ID, sentToDwpMigration.getEventId());
+        assertEquals(SENT_TO_DWP_MIGRATION_EVENT_SUMMARY, sentToDwpMigration.getEventSummary());
+        assertEquals(SENT_TO_DWP_MIGRATION_EVENT_DESCRIPTION, sentToDwpMigration.getEventDescription());
+    }
+
+    @Test
+    @DisplayName("Skip if there's no data in case details")
+    void shouldThrowErrorWhenNoData() {
+        caseDetails = CaseDetails.builder().data(null).id(1234L).build();
+
+        assertThatThrownBy(() -> sentToDwpMigration.migrate(caseDetails))
+            .hasMessageContaining("case data is empty");
+    }
+
+    @Test
+    @DisplayName("Skip if dwpDueDate is null")
+    void shouldThrowErrorWhenDwpDueDateIsNull() {
+        caseDetails = CaseDetails.builder().data(buildCaseDataMap(sscsCaseData)).id(1234L).build();
+
+        assertThatThrownBy(() -> sentToDwpMigration.migrate(caseDetails))
+            .hasMessageContaining("FTA response due date is empty");
+    }
+
+    @Test
+    @DisplayName("Skip if dateSentToDwp is already set")
+    void shouldThrowErrorWhenDateSentToDwpIsSet() {
+        LocalDate sentToDwpDate = LocalDate.now().minusDays(15);
+        sscsCaseData.setDateSentToDwp(sentToDwpDate.toString());
+        caseDetails = CaseDetails.builder().data(buildCaseDataMap(sscsCaseData)).id(1234L).build();
+
+        assertThatThrownBy(() -> sentToDwpMigration.migrate(caseDetails))
+            .hasMessageContaining(DATE_SENT_TO_DWP + " is already set");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"childSupport", "UC", "attendanceAllowance"})
+    @DisplayName("Should migrate case")
+    void shouldMigrate(String benefitShortName) {
+        sscsCaseData.getAppeal().setBenefitType(BenefitType.builder().code(benefitShortName).build());
+        LocalDate dueDate = LocalDate.now().plusDays(25);
+        sscsCaseData.setDwpDueDate(dueDate.toString());
+        sscsCaseData.setHmctsDwpState(null);
+        caseDetails = CaseDetails.builder().data(buildCaseDataMap(sscsCaseData)).id(1234L).build();
+
+        sentToDwpMigration.migrate(caseDetails);
+
+        assertNotNull(caseDetails.getData().get(HMCTS_DWP_STATE));
+        assertNotNull(caseDetails.getData().get(DATE_SENT_TO_DWP));
+        String expectedSentDate = benefitShortName.equals("childSupport")
+            ? dueDate.minusDays(RESPONSE_DUE_DAYS_CM).toString() : dueDate.minusDays(RESPONSE_DUE_DAYS).toString();
+        assertEquals(expectedSentDate, caseDetails.getData().get(DATE_SENT_TO_DWP));
+    }
+
+    @Test
+    @DisplayName("Should migrate case and not overwrite hmctsDwpSate")
+    void shouldMigrateAndKeepExistingHmctsDwpSate() {
+        LocalDate dueDate = LocalDate.now().plusDays(13);
+        sscsCaseData.setDwpDueDate(dueDate.toString());
+        sscsCaseData.setHmctsDwpState("someState");
+        caseDetails = CaseDetails.builder().data(buildCaseDataMap(sscsCaseData)).id(1234L).build();
+
+        sentToDwpMigration.migrate(caseDetails);
+
+        assertEquals("someState", caseDetails.getData().get(HMCTS_DWP_STATE));
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/migration/service/migrate/SentToDwpMigrationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/migration/service/migrate/SentToDwpMigrationTest.java
@@ -108,17 +108,4 @@ class SentToDwpMigrationTest {
             ? dueDate.minusDays(RESPONSE_DUE_DAYS_CM).toString() : dueDate.minusDays(RESPONSE_DUE_DAYS).toString();
         assertEquals(expectedSentDate, caseDetails.getData().get(DATE_SENT_TO_DWP));
     }
-
-    @Test
-    @DisplayName("Should migrate case and not overwrite hmctsDwpSate")
-    void shouldMigrateAndKeepExistingHmctsDwpSate() {
-        LocalDate dueDate = LocalDate.now().plusDays(13);
-        sscsCaseData.setDwpDueDate(dueDate.toString());
-        sscsCaseData.setHmctsDwpState("someState");
-        caseDetails = CaseDetails.builder().data(buildCaseDataMap(sscsCaseData)).id(1234L).build();
-
-        sentToDwpMigration.migrate(caseDetails);
-
-        assertEquals("someState", caseDetails.getData().get(HMCTS_DWP_STATE));
-    }
 }

--- a/src/test/java/uk/gov/hmcts/reform/migration/service/migrate/SentToDwpMigrationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/migration/service/migrate/SentToDwpMigrationTest.java
@@ -1,6 +1,6 @@
 package uk.gov.hmcts.reform.migration.service.migrate;
 
-import java.time.LocalDate;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -9,9 +9,10 @@ import org.junit.jupiter.params.provider.ValueSource;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.sscs.ccd.domain.BenefitType;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
-
-import java.util.List;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseDetails;
+
+import java.time.LocalDate;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/src/test/java/uk/gov/hmcts/reform/migration/service/migrate/SentToDwpMigrationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/migration/service/migrate/SentToDwpMigrationTest.java
@@ -91,7 +91,7 @@ class SentToDwpMigrationTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"childSupport", "UC", "attendanceAllowance"})
+    @ValueSource(strings = {"childSupport", "UC"})
     @DisplayName("Should migrate case")
     void shouldMigrate(String benefitShortName) {
         sscsCaseData.getAppeal().setBenefitType(BenefitType.builder().code(benefitShortName).build());

--- a/src/test/java/uk/gov/hmcts/reform/migration/service/migrate/SentToDwpMigrationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/migration/service/migrate/SentToDwpMigrationTest.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.CsvSource;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.sscs.ccd.domain.BenefitType;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
@@ -71,33 +71,32 @@ class SentToDwpMigrationTest {
     }
 
     @Test
-    @DisplayName("Skip if dwpDueDate is null")
+    @DisplayName("Skip if dwpDueDate is correct")
     void shouldThrowErrorWhenDwpDueDateIsNull() {
+        LocalDate dueDate = LocalDate.now().plusDays(5);
+        sscsCaseData.setDwpDueDate(dueDate.toString());
+        sscsCaseData.setDateSentToDwp(dueDate.minusDays(RESPONSE_DUE_DAYS_CM).toString());
         caseDetails = CaseDetails.builder().data(buildCaseDataMap(sscsCaseData)).id(1234L).build();
 
         assertThatThrownBy(() -> sentToDwpMigration.migrate(caseDetails))
-            .hasMessageContaining("FTA response due date is empty");
-    }
-
-    @Test
-    @DisplayName("Skip if dateSentToDwp is already set")
-    void shouldThrowErrorWhenDateSentToDwpIsSet() {
-        LocalDate sentToDwpDate = LocalDate.now().minusDays(15);
-        sscsCaseData.setDateSentToDwp(sentToDwpDate.toString());
-        caseDetails = CaseDetails.builder().data(buildCaseDataMap(sscsCaseData)).id(1234L).build();
-
-        assertThatThrownBy(() -> sentToDwpMigration.migrate(caseDetails))
-            .hasMessageContaining(DATE_SENT_TO_DWP + " is already set");
+            .hasMessageContaining("dateSentToDwp is correct");
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"childSupport", "UC"})
+    @CsvSource({
+        "childSupport, null",
+        "childSupport, 136",
+        "UC, null"
+    })
     @DisplayName("Should migrate case")
-    void shouldMigrate(String benefitShortName) {
+    void shouldMigrate(String benefitShortName, String sentToDateDifference) {
         sscsCaseData.getAppeal().setBenefitType(BenefitType.builder().code(benefitShortName).build());
         LocalDate dueDate = LocalDate.now().plusDays(25);
         sscsCaseData.setDwpDueDate(dueDate.toString());
         sscsCaseData.setHmctsDwpState(null);
+        sscsCaseData.setDateSentToDwp(sentToDateDifference.equals("null")
+                                          ? null
+                                          : dueDate.minusDays(Long.parseLong(sentToDateDifference)).toString());
         caseDetails = CaseDetails.builder().data(buildCaseDataMap(sscsCaseData)).id(1234L).build();
 
         sentToDwpMigration.migrate(caseDetails);

--- a/src/test/java/uk/gov/hmcts/reform/migration/service/migrate/SentToDwpMigrationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/migration/service/migrate/SentToDwpMigrationTest.java
@@ -71,8 +71,18 @@ class SentToDwpMigrationTest {
     }
 
     @Test
-    @DisplayName("Skip if dwpDueDate is correct")
+    @DisplayName("Skip if dwpDueDate is null")
     void shouldThrowErrorWhenDwpDueDateIsNull() {
+        sscsCaseData.setDwpDueDate(null);
+        caseDetails = CaseDetails.builder().data(buildCaseDataMap(sscsCaseData)).id(1234L).build();
+
+        assertThatThrownBy(() -> sentToDwpMigration.migrate(caseDetails))
+            .hasMessageContaining("FTA response due date is empty");
+    }
+
+    @Test
+    @DisplayName("Skip if dateSentToDwp is correct")
+    void shouldThrowErrorWhenDateSentToDwpIsCorrect() {
         LocalDate dueDate = LocalDate.now().plusDays(5);
         sscsCaseData.setDwpDueDate(dueDate.toString());
         sscsCaseData.setDateSentToDwp(dueDate.minusDays(RESPONSE_DUE_DAYS_CM).toString());


### PR DESCRIPTION
### Jira link

See [SSCSCI-2693](https://tools.hmcts.net/jira/browse/SSCSCI-2693)

### Change description

New migration updating `hmctsDwpState` and `dateSentToDwp` for CM/UC cases where the confirm confidentiality event was triggered but the Sent to FTA event wasn't.

### Testing done

Ran it against AAT using these cases: 

- 1784713989883838
- 1784713380669141
- 1784720436898764


### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [x] Yes
  * [ ] No

CVE-2025-15104: false positive. Flagged for [com.networknt/json-schema-validator](https://github.com/networknt/json-schema-validator)@1.5.8 but the vulnerability is for https://github.com/validator/validator.

CVE-2026-54399: false positive. Flagged for org.apache.httpcomponents/httpcore@4.4.16 but the vulnerability is for org.apache.httpcomponents.core5/httpcore5. These are different artifacts and the vulnerability affects only version 5, source: https://lists.apache.org/thread/zmxh1pl2zohov5ntdh4lt85gfrlchgpy 

CVE-2026-54428 false positive. Flagged for org.apache.httpcomponents/httpcore@4.4.16 but the vulnerability is for org.apache.httpcomponents.core5/httpcore5. These are different artifacts and the vulnerability affects only version 5, source: https://lists.apache.org/thread/5zjp8vczvxq19pw2rvhs21q446bhl0sd

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change

