### PR TITLE
SSCSCI-2705: CSAT migration for response received state

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-  <suppress until="2026-08-13">
+  <suppress until="2026-09-13">
     <cve>CVE-2025-15104</cve>
     <cve>CVE-2026-54399</cve>
     <cve>CVE-2026-54428</cve>
-    <cve>CVE-2026-63263</cve>
-    <cve>CVE-2026-63144</cve>
   </suppress>
 </suppressions>

--- a/src/main/java/uk/gov/hmcts/reform/migration/service/migrate/SentToDwpMigration.java
+++ b/src/main/java/uk/gov/hmcts/reform/migration/service/migrate/SentToDwpMigration.java
@@ -62,7 +62,8 @@ public class SentToDwpMigration extends CaseMigrationProcessor {
             }
 
             if (!RESPONSE_RECEIVED.equals(sscsCaseData.getState())) {
-                throw new IllegalStateException("Skipping migration as case state is " + sscsCaseData.getState().getId());
+                throw new IllegalStateException("Skipping migration as case state is "
+                                                    + sscsCaseData.getState().getId());
             }
 
             if (shouldMigrate(sscsCaseData, caseDetails.getId().toString())) {

--- a/src/main/java/uk/gov/hmcts/reform/migration/service/migrate/SentToDwpMigration.java
+++ b/src/main/java/uk/gov/hmcts/reform/migration/service/migrate/SentToDwpMigration.java
@@ -61,9 +61,8 @@ public class SentToDwpMigration extends CaseMigrationProcessor {
                 throw new IllegalStateException("Skipping migration as FTA response due date is empty");
             }
 
-            if (!RESPONSE_RECEIVED.equals(sscsCaseData.getState())) {
-                throw new IllegalStateException("Skipping migration as case state is "
-                                                    + sscsCaseData.getState().getId());
+            if (!RESPONSE_RECEIVED.getId().equals(caseDetails.getState())) {
+                throw new IllegalStateException("Skipping migration as case state is " + caseDetails.getState());
             }
 
             if (shouldMigrate(sscsCaseData, caseDetails.getId().toString())) {

--- a/src/main/java/uk/gov/hmcts/reform/migration/service/migrate/SentToDwpMigration.java
+++ b/src/main/java/uk/gov/hmcts/reform/migration/service/migrate/SentToDwpMigration.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import static java.util.Objects.isNull;
 import static uk.gov.hmcts.reform.migration.repository.EncodedStringCaseList.findCases;
+import static uk.gov.hmcts.reform.sscs.ccd.domain.State.RESPONSE_RECEIVED;
 import static uk.gov.hmcts.reform.sscs.ccd.service.UpdateCcdCaseService.UpdateResult;
 
 @Service
@@ -60,9 +61,18 @@ public class SentToDwpMigration extends CaseMigrationProcessor {
                 throw new RuntimeException("Skipping migration as FTA response due date is empty");
             }
 
+            if (!RESPONSE_RECEIVED.equals(sscsCaseData.getState())) {
+                throw new RuntimeException("Skipping migration as case state is " + sscsCaseData.getState().getId());
+            }
+
             if (shouldMigrate(sscsCaseData, caseDetails.getId().toString())) {
                 data.put(DATE_SENT_TO_DWP, calculateSentToDwpDate(sscsCaseData));
-                data.put(HMCTS_DWP_STATE, SENT_TO_DWP);
+                if (isNull(sscsCaseData.getHmctsDwpState())) {
+                    data.put(HMCTS_DWP_STATE, SENT_TO_DWP);
+                    log.info("Setting hmctsDwpState to {}", SENT_TO_DWP);
+                } else {
+                    log.info("hmctsDwpState is already set to {}", sscsCaseData.getHmctsDwpState());
+                }
             } else {
                 throw new RuntimeException("Skipping case for migration due to " + DATE_SENT_TO_DWP
                                                + " is correct");

--- a/src/main/java/uk/gov/hmcts/reform/migration/service/migrate/SentToDwpMigration.java
+++ b/src/main/java/uk/gov/hmcts/reform/migration/service/migrate/SentToDwpMigration.java
@@ -58,11 +58,11 @@ public class SentToDwpMigration extends CaseMigrationProcessor {
         if (data != null) {
             SscsCaseData sscsCaseData = objectMapper.convertValue(data, SscsCaseData.class);
             if (isNull(data.get(DWP_DUE_DATE))) {
-                throw new RuntimeException("Skipping migration as FTA response due date is empty");
+                throw new IllegalStateException("Skipping migration as FTA response due date is empty");
             }
 
             if (!RESPONSE_RECEIVED.equals(sscsCaseData.getState())) {
-                throw new RuntimeException("Skipping migration as case state is " + sscsCaseData.getState().getId());
+                throw new IllegalStateException("Skipping migration as case state is " + sscsCaseData.getState().getId());
             }
 
             if (shouldMigrate(sscsCaseData, caseDetails.getId().toString())) {
@@ -74,11 +74,11 @@ public class SentToDwpMigration extends CaseMigrationProcessor {
                     log.info("hmctsDwpState is already set to {}", sscsCaseData.getHmctsDwpState());
                 }
             } else {
-                throw new RuntimeException("Skipping case for migration due to " + DATE_SENT_TO_DWP
+                throw new IllegalStateException("Skipping case for migration due to " + DATE_SENT_TO_DWP
                                                + " is correct");
             }
         } else {
-            throw new RuntimeException("Skipping case for migration due to case data is empty.");
+            throw new IllegalStateException("Skipping case for migration due to case data is empty.");
         }
 
         return new UpdateResult(getEventSummary(), getEventDescription());

--- a/src/test/java/uk/gov/hmcts/reform/migration/service/migrate/SentToDwpMigrationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/migration/service/migrate/SentToDwpMigrationTest.java
@@ -22,9 +22,12 @@ import static uk.gov.hmcts.reform.migration.repository.EncodedStringCaseListTest
 import static uk.gov.hmcts.reform.migration.repository.EncodedStringCaseListTest.ENCODED_STRING;
 import static uk.gov.hmcts.reform.migration.service.migrate.SentToDwpMigration.DATE_SENT_TO_DWP;
 import static uk.gov.hmcts.reform.migration.service.migrate.SentToDwpMigration.HMCTS_DWP_STATE;
+import static uk.gov.hmcts.reform.migration.service.migrate.SentToDwpMigration.SENT_TO_DWP;
 import static uk.gov.hmcts.reform.migration.service.migrate.SentToDwpMigration.SENT_TO_DWP_MIGRATION_EVENT_DESCRIPTION;
 import static uk.gov.hmcts.reform.migration.service.migrate.SentToDwpMigration.SENT_TO_DWP_MIGRATION_EVENT_ID;
 import static uk.gov.hmcts.reform.migration.service.migrate.SentToDwpMigration.SENT_TO_DWP_MIGRATION_EVENT_SUMMARY;
+import static uk.gov.hmcts.reform.sscs.ccd.domain.State.RESPONSE_RECEIVED;
+import static uk.gov.hmcts.reform.sscs.ccd.domain.State.WITH_DWP;
 import static uk.gov.hmcts.reform.sscs.ccd.util.CaseDataUtils.buildCaseData;
 import static uk.gov.hmcts.reform.sscs.ccd.util.CaseDataUtils.buildCaseDataMap;
 
@@ -73,6 +76,7 @@ class SentToDwpMigrationTest {
     @Test
     @DisplayName("Skip if dwpDueDate is null")
     void shouldThrowErrorWhenDwpDueDateIsNull() {
+        sscsCaseData.setState(RESPONSE_RECEIVED);
         sscsCaseData.setDwpDueDate(null);
         caseDetails = CaseDetails.builder().data(buildCaseDataMap(sscsCaseData)).id(1234L).build();
 
@@ -81,15 +85,45 @@ class SentToDwpMigrationTest {
     }
 
     @Test
+    @DisplayName("Skip if case state is not Response received")
+    void shouldThrowErrorWhenCaseStateIsNotResponseReceived() {
+        sscsCaseData.setState(WITH_DWP);
+        sscsCaseData.setDwpDueDate(LocalDate.now().toString());
+        caseDetails = CaseDetails.builder().data(buildCaseDataMap(sscsCaseData)).id(1234L).build();
+
+        assertThatThrownBy(() -> sentToDwpMigration.migrate(caseDetails))
+            .hasMessageContaining("Skipping migration as case state is");
+    }
+
+    @Test
     @DisplayName("Skip if dateSentToDwp is correct")
     void shouldThrowErrorWhenDateSentToDwpIsCorrect() {
         LocalDate dueDate = LocalDate.now().plusDays(5);
+        sscsCaseData.setState(RESPONSE_RECEIVED);
         sscsCaseData.setDwpDueDate(dueDate.toString());
         sscsCaseData.setDateSentToDwp(dueDate.minusDays(RESPONSE_DUE_DAYS_CM).toString());
         caseDetails = CaseDetails.builder().data(buildCaseDataMap(sscsCaseData)).id(1234L).build();
 
         assertThatThrownBy(() -> sentToDwpMigration.migrate(caseDetails))
             .hasMessageContaining("dateSentToDwp is correct");
+    }
+
+    @Test
+    @DisplayName("Should not overwrite hmctsDwpState when migrating case")
+    void shouldNotChangeHmctsDwpStateIfSet() {
+        sscsCaseData.setState(RESPONSE_RECEIVED);
+        LocalDate dueDate = LocalDate.now().plusDays(32);
+        sscsCaseData.setDwpDueDate(dueDate.toString());
+        sscsCaseData.setHmctsDwpState("someHmctsDwpState");
+        sscsCaseData.setDateSentToDwp(null);
+        caseDetails = CaseDetails.builder().data(buildCaseDataMap(sscsCaseData)).id(1234L).build();
+
+        sentToDwpMigration.migrate(caseDetails);
+
+        assertNotNull(caseDetails.getData().get(HMCTS_DWP_STATE));
+        assertNotNull(caseDetails.getData().get(DATE_SENT_TO_DWP));
+        assertEquals(dueDate.minusDays(RESPONSE_DUE_DAYS_CM).toString(), caseDetails.getData().get(DATE_SENT_TO_DWP));
+        assertEquals("someHmctsDwpState", caseDetails.getData().get(HMCTS_DWP_STATE));
     }
 
     @ParameterizedTest
@@ -101,6 +135,7 @@ class SentToDwpMigrationTest {
     @DisplayName("Should migrate case")
     void shouldMigrate(String benefitShortName, String sentToDateDifference) {
         sscsCaseData.getAppeal().setBenefitType(BenefitType.builder().code(benefitShortName).build());
+        sscsCaseData.setState(RESPONSE_RECEIVED);
         LocalDate dueDate = LocalDate.now().plusDays(25);
         sscsCaseData.setDwpDueDate(dueDate.toString());
         sscsCaseData.setHmctsDwpState(null);
@@ -116,5 +151,6 @@ class SentToDwpMigrationTest {
         String expectedSentDate = benefitShortName.equals("childSupport")
             ? dueDate.minusDays(RESPONSE_DUE_DAYS_CM).toString() : dueDate.minusDays(RESPONSE_DUE_DAYS).toString();
         assertEquals(expectedSentDate, caseDetails.getData().get(DATE_SENT_TO_DWP));
+        assertEquals(SENT_TO_DWP, caseDetails.getData().get(HMCTS_DWP_STATE));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/migration/service/migrate/SentToDwpMigrationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/migration/service/migrate/SentToDwpMigrationTest.java
@@ -76,9 +76,9 @@ class SentToDwpMigrationTest {
     @Test
     @DisplayName("Skip if dwpDueDate is null")
     void shouldThrowErrorWhenDwpDueDateIsNull() {
-        sscsCaseData.setState(RESPONSE_RECEIVED);
         sscsCaseData.setDwpDueDate(null);
         caseDetails = CaseDetails.builder().data(buildCaseDataMap(sscsCaseData)).id(1234L).build();
+        caseDetails.setState(RESPONSE_RECEIVED.getId());
 
         assertThatThrownBy(() -> sentToDwpMigration.migrate(caseDetails))
             .hasMessageContaining("FTA response due date is empty");
@@ -87,9 +87,9 @@ class SentToDwpMigrationTest {
     @Test
     @DisplayName("Skip if case state is not Response received")
     void shouldThrowErrorWhenCaseStateIsNotResponseReceived() {
-        sscsCaseData.setState(WITH_DWP);
         sscsCaseData.setDwpDueDate(LocalDate.now().toString());
         caseDetails = CaseDetails.builder().data(buildCaseDataMap(sscsCaseData)).id(1234L).build();
+        caseDetails.setState(WITH_DWP.getId());
 
         assertThatThrownBy(() -> sentToDwpMigration.migrate(caseDetails))
             .hasMessageContaining("Skipping migration as case state is");
@@ -99,10 +99,10 @@ class SentToDwpMigrationTest {
     @DisplayName("Skip if dateSentToDwp is correct")
     void shouldThrowErrorWhenDateSentToDwpIsCorrect() {
         LocalDate dueDate = LocalDate.now().plusDays(5);
-        sscsCaseData.setState(RESPONSE_RECEIVED);
         sscsCaseData.setDwpDueDate(dueDate.toString());
         sscsCaseData.setDateSentToDwp(dueDate.minusDays(RESPONSE_DUE_DAYS_CM).toString());
         caseDetails = CaseDetails.builder().data(buildCaseDataMap(sscsCaseData)).id(1234L).build();
+        caseDetails.setState(RESPONSE_RECEIVED.getId());
 
         assertThatThrownBy(() -> sentToDwpMigration.migrate(caseDetails))
             .hasMessageContaining("dateSentToDwp is correct");
@@ -111,12 +111,12 @@ class SentToDwpMigrationTest {
     @Test
     @DisplayName("Should not overwrite hmctsDwpState when migrating case")
     void shouldNotChangeHmctsDwpStateIfSet() {
-        sscsCaseData.setState(RESPONSE_RECEIVED);
         LocalDate dueDate = LocalDate.now().plusDays(32);
         sscsCaseData.setDwpDueDate(dueDate.toString());
         sscsCaseData.setHmctsDwpState("someHmctsDwpState");
         sscsCaseData.setDateSentToDwp(null);
         caseDetails = CaseDetails.builder().data(buildCaseDataMap(sscsCaseData)).id(1234L).build();
+        caseDetails.setState(RESPONSE_RECEIVED.getId());
 
         sentToDwpMigration.migrate(caseDetails);
 
@@ -135,7 +135,6 @@ class SentToDwpMigrationTest {
     @DisplayName("Should migrate case")
     void shouldMigrate(String benefitShortName, String sentToDateDifference) {
         sscsCaseData.getAppeal().setBenefitType(BenefitType.builder().code(benefitShortName).build());
-        sscsCaseData.setState(RESPONSE_RECEIVED);
         LocalDate dueDate = LocalDate.now().plusDays(25);
         sscsCaseData.setDwpDueDate(dueDate.toString());
         sscsCaseData.setHmctsDwpState(null);
@@ -143,6 +142,7 @@ class SentToDwpMigrationTest {
                                           ? null
                                           : dueDate.minusDays(Long.parseLong(sentToDateDifference)).toString());
         caseDetails = CaseDetails.builder().data(buildCaseDataMap(sscsCaseData)).id(1234L).build();
+        caseDetails.setState(RESPONSE_RECEIVED.getId());
 
         sentToDwpMigration.migrate(caseDetails);
 


### PR DESCRIPTION
### Jira link

See [SSCSCI-2705](https://tools.hmcts.net/jira/browse/SSCSCI-2705)

### Change description

Update Sent to Dwp migration for Response received state

### Testing done



### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [x] Yes
  * [ ] No

CVE-2025-15104: false positive. Flagged for [com.networknt/json-schema-validator](https://github.com/networknt/json-schema-validator)@1.5.8 but the vulnerability is for https://github.com/validator/validator.

CVE-2026-54399: false positive. Flagged for org.apache.httpcomponents/httpcore@4.4.16 but the vulnerability is for org.apache.httpcomponents.core5/httpcore5. These are different artifacts and the vulnerability affects only version 5, source: https://lists.apache.org/thread/zmxh1pl2zohov5ntdh4lt85gfrlchgpy 

CVE-2026-54428 false positive. Flagged for org.apache.httpcomponents/httpcore@4.4.16 but the vulnerability is for org.apache.httpcomponents.core5/httpcore5. These are different artifacts and the vulnerability affects only version 5, source: https://lists.apache.org/thread/5zjp8vczvxq19pw2rvhs21q446bhl0sd

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
